### PR TITLE
Added Color Library (2nd attempt)

### DIFF
--- a/include/color.h
+++ b/include/color.h
@@ -10,6 +10,7 @@ enum ColorPalette {
 	BLUE   = 0x0080FFFF,
 	PURPLE = 0x6600CCFF,
 	WHITE  = 0xFFFFFFFF,
+	GRAY   = 0xBABABAFF,
 	BLACK  = 0x00000000
 };
 

--- a/include/color.h
+++ b/include/color.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#define NUM_COLORS 8
+
+enum ColorPalette {
+	RED    = 0xCC0000FF,
+	ORANGE = 0xEE8000FF,
+	YELLOW = 0xFFCC00FF,
+	GREEN  = 0x00CC00FF,
+	BLUE   = 0x0080FFFF,
+	PURPLE = 0x6600CCFF,
+	WHITE  = 0xFFFFFFFF,
+	BLACK  = 0x00000000
+};
+
+int rainbow();

--- a/source/color.cpp
+++ b/source/color.cpp
@@ -1,0 +1,15 @@
+#include "color.h"
+#include "libtww/SSystem/SComponent/c_counter.h"
+
+#define NUM_RAINBOW_COLORS 6
+
+int rainbow() {
+	switch(cCt_getFrameCount() % NUM_RAINBOW_COLORS) {
+		case 0: return ColorPalette::RED;
+		case 1: return ColorPalette::ORANGE;
+		case 2: return ColorPalette::YELLOW;
+		case 3: return ColorPalette::GREEN;
+		case 4: return ColorPalette::BLUE;
+		default: return ColorPalette::PURPLE;
+	}
+}

--- a/source/lib.cpp
+++ b/source/lib.cpp
@@ -1,5 +1,6 @@
 #include "lib.h"
 #include "font.h"
+#include "color.h"
 #include "utils/draw.h"
 #include "utils/hook.h"
 #include "utils/card.h"
@@ -93,12 +94,12 @@ void displaySplash() {
         Vec2 icon_scale = {32, 32};
 
         // Draw the string
-        Font::GZ_drawStr(name, splash_x, splash_y, 0xFFFFFFFF, true, 18.0f);
-        Font::GZ_drawStr(url, splash_x, splash_y + 25.0f, 0xFFFFFFFF, true, 18.0f);
-
+        Font::GZ_drawStr(name, splash_x, splash_y, ColorPalette::WHITE, true, 18.0f);
+        Font::GZ_drawStr(url, splash_x, splash_y + 25.0f, ColorPalette::WHITE, true, 18.0f);
+        
         // Draw twwgz's logo
         if (l_twwgzIconTex.loadCode == TexCode::TEX_OK) {
-            Draw::drawRect(0xFFFFFFFF, icon_pos, icon_scale, &l_twwgzIconTex._texObj);
+            Draw::drawRect(ColorPalette::WHITE, icon_pos, icon_scale, &l_twwgzIconTex._texObj);
         }
 
         // Then when splash_time hits < 1, it won't display the string or logo anymore

--- a/source/lib.cpp
+++ b/source/lib.cpp
@@ -96,7 +96,7 @@ void displaySplash() {
         // Draw the string
         Font::GZ_drawStr(name, splash_x, splash_y, ColorPalette::WHITE, true, 18.0f);
         Font::GZ_drawStr(url, splash_x, splash_y + 25.0f, ColorPalette::WHITE, true, 18.0f);
-        
+
         // Draw twwgz's logo
         if (l_twwgzIconTex.loadCode == TexCode::TEX_OK) {
             Draw::drawRect(ColorPalette::WHITE, icon_pos, icon_scale, &l_twwgzIconTex._texObj);

--- a/source/menus/memory_editor_menu.cpp
+++ b/source/menus/memory_editor_menu.cpp
@@ -1,10 +1,11 @@
 #include "menus/memory_editor_menu.h"
 #include "menus/settings_menu.h"
 #include "libtww/MSL_C/string.h"
+#include "color.h"
 
 #define MAX_DISPLAY_LINES 15
-#define WHITE_RGBA 0xFFFFFFFF
-#define ADDRESS_RGBA 0xBABABAFF
+#define WHITE_RGBA ColorPalette::WHITE
+#define ADDRESS_RGBA ColorPalette::GRAY
 #define LINE_X_OFFSET 20.0f
 #define LINE_BYTE_OFFSET 100.0f
 

--- a/source/menus/tools_menu.cpp
+++ b/source/menus/tools_menu.cpp
@@ -6,6 +6,7 @@
 #include "libtww/MSL_C/string.h"
 #include "lib.h"
 #include "font.h"
+#include "color.h"
 #include "utils/draw.h"
 #include "utils/hook.h"
 #include "commands.h"
@@ -81,11 +82,11 @@ void ToolsMenu::displayLinkInfo() {
         tww_sprintf(link_y, "y-pos: %.4f", playerAc->mCurrent.mPosition.y);
         tww_sprintf(link_z, "z-pos: %.4f", playerAc->mCurrent.mPosition.z);
 
-        Font::GZ_drawStr(link_angle, 450.f, 200.f, 0xFFFFFFFF, g_dropShadows);
-        Font::GZ_drawStr(link_speed, 450.f, 220.f, 0xFFFFFFFF, g_dropShadows);
-        Font::GZ_drawStr(link_x, 450.f, 240.f, 0xFFFFFFFF, g_dropShadows);
-        Font::GZ_drawStr(link_y, 450.f, 260.f, 0xFFFFFFFF, g_dropShadows);
-        Font::GZ_drawStr(link_z, 450.f, 280.f, 0xFFFFFFFF, g_dropShadows);
+        Font::GZ_drawStr(link_angle, 450.f, 200.f, ColorPalette::WHITE, g_dropShadows);
+        Font::GZ_drawStr(link_speed, 450.f, 220.f, ColorPalette::WHITE, g_dropShadows);
+        Font::GZ_drawStr(link_x, 450.f, 240.f, ColorPalette::WHITE, g_dropShadows);
+        Font::GZ_drawStr(link_y, 450.f, 260.f, ColorPalette::WHITE, g_dropShadows);
+        Font::GZ_drawStr(link_z, 450.f, 280.f, ColorPalette::WHITE, g_dropShadows);
     }
 }
 
@@ -97,6 +98,6 @@ void ToolsMenu::displayZombieHoverInfo() {
     tww_sprintf(a_presses_str, "A: %d", GZ_getAPressesPerWindow());
     tww_sprintf(b_presses_str, "B: %d", GZ_getBPressesPerWindow());
 
-    Font::GZ_drawStr(a_presses_str, 450.f, 320.f, 0x00CC00FF, g_dropShadows);
-    Font::GZ_drawStr(b_presses_str, 450.f, 340.f, 0xCC0000FF, g_dropShadows);
+    Font::GZ_drawStr(a_presses_str, 450.f, 320.f, ColorPalette::GREEN, g_dropShadows);
+    Font::GZ_drawStr(b_presses_str, 450.f, 340.f, ColorPalette::RED, g_dropShadows);
 }

--- a/source/utils/cursor.cpp
+++ b/source/utils/cursor.cpp
@@ -1,5 +1,6 @@
 #include "utils/cursor.h"
 #include "controller.h"
+#include "color.h"
 
 int g_cursorColor;
 int g_cursorColorType;
@@ -58,22 +59,22 @@ void Cursor::move(int max_x, int max_y) {
 void GZ_setCursorColor() {
     switch (g_cursorColorType) {
     case CURSOR_GREEN:
-        g_cursorColor = 0x00CC00FF;
+        g_cursorColor = ColorPalette::GREEN;
         break;
     case CURSOR_BLUE:
-        g_cursorColor = 0x0080FFFF;
+        g_cursorColor = ColorPalette::BLUE;
         break;
     case CURSOR_RED:
-        g_cursorColor = 0xCC0000FF;
+        g_cursorColor = ColorPalette::RED;
         break;
     case CURSOR_ORANGE:
-        g_cursorColor = 0xEE8000FF;
+        g_cursorColor = ColorPalette::ORANGE;
         break;
     case CURSOR_YELLOW:
-        g_cursorColor = 0xFFCC00FF;
+        g_cursorColor = ColorPalette::YELLOW;
         break;
     case CURSOR_PURPLE:
-        g_cursorColor = 0x6600CCFF;
+        g_cursorColor = ColorPalette::PURPLE;
         break;
     }
 }


### PR DESCRIPTION
The color hex values for the cursor are hardcoded and there's no way to access them in order to keep colors consistent across the practice rom, so I made a color library. This way, it's impossible for a typo to accidentally make the shade of red in one tool different from another, for example, and no developer has to waste time looking up what shade of blue the rest of the rom uses.