### PR TITLE
Quest status menu now lets players edit wallet size

### DIFF
--- a/external/libtww/d/com/d_com_inf_game.h
+++ b/external/libtww/d/com/d_com_inf_game.h
@@ -309,14 +309,6 @@ inline void dComIfGs_setMagic(uint8_t amount) {
     g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setMagic(amount);
 }
 
-inline uint16_t dComIfGs_getRupee() {
-    return g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getRupee();
-}
-
-inline void dComIfGs_setRupee(uint16_t amount) {
-    g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setRupee(amount);
-}
-
 inline void dComIfGs_setForestWaterTimer(uint16_t frames) {
     g_dComIfG_gameInfo.info.getPlayer().getItemRecord().setForestWaterTimer(frames);
 }

--- a/external/libtww/d/save/d_save.h
+++ b/external/libtww/d/save/d_save.h
@@ -152,6 +152,7 @@ class dSv_player_status_a_c {
 public:
     u16& getMaxLife() { return mMaxLife; }
     u8& getMaxMagic() { return mMaxMagic; }
+    u8& getWalletSize() { return mWalletSize; }
     u16& getLife() { return mLife; }
     u8& getMagic() { return mMagic; }
     u16& getRupee() { return mRupee; }
@@ -160,6 +161,7 @@ public:
     void setMagic(u8 magic) { mMagic = magic; }
     void setMaxMagic(u8 max) { mMaxMagic = max; }
     void setRupee(u16 rupees) { mRupee = rupees; }
+    void setWalletSize(u8 size) { mWalletSize = size; }
     void setLife(u16 life) { mLife = life; }
     void setMaxLife(u16 max) { mMaxLife = max; }
     void setSelectEquip(int item_index, u8 item) { mSelectEquip[item_index] = item; }

--- a/include/menus/quest_status_menu.h
+++ b/include/menus/quest_status_menu.h
@@ -19,6 +19,13 @@ enum Magic {
     SINGLE_MAGIC = 16,
     DOUBLE_MAGIC = 32
 };
+
+enum WalletSize {
+    WALLET_200 = 0,
+    WALLET_1000 = 1,
+    WALLET_5000 = 2
+};
+
 enum Quiver {
     NO_QUIVER = 0,
     ARROWS_30 = 30,
@@ -27,12 +34,11 @@ enum Quiver {
 };
 
 enum BombBag {
- NO_BOMBBAG  = 0,
+    NO_BOMBBAG = 0,
     BOMBS_30 = 30,
     BOMBS_60 = 60,
     BOMBS_99 = 99
 };
-
 
 enum HerosCharm {
     NO_HEROS_CHARM = 0,
@@ -70,6 +76,7 @@ enum QuestStatusMenuItems {
     MENU_ITEM_SWORD,
     MENU_ITEM_SHIELD,
     MENU_ITEM_MAGIC,
+    MENU_ITEM_WALLET,
     MENU_ITEM_QUIVER,
     MENU_ITEM_BOMBAG,
     MENU_ITEM_POWER_BRACELETS,

--- a/source/cheats.cpp
+++ b/source/cheats.cpp
@@ -1,5 +1,6 @@
 #include "cheats.h"
 #include "commands.h"
+#include "menus/quest_status_menu.h"
 #include "libtww/d/com/d_com_inf_game.h"
 
 
@@ -87,14 +88,14 @@ void GZ_applyCheats() {
         u8 wallet_size = g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getWalletSize();
 
         switch (wallet_size) {
-        case 0:
-            dComIfGs_setRupee(200);
+        case WALLET_200:
+            g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setRupee(200);
             break;
-        case 1:
-            dComIfGs_setRupee(1000);
+        case WALLET_1000:
+            g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setRupee(1000);
             break;
-        case 2:
-            dComIfGs_setRupee(5000);
+        case WALLET_5000:
+            g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setRupee(5000);
             break;
         }
     }

--- a/source/cheats.cpp
+++ b/source/cheats.cpp
@@ -84,7 +84,19 @@ void GZ_applyCheats() {
     }
 
     if (GZ_checkCheat(InfiniteRupees)) {
-        dComIfGs_setRupee(5000);
+        u8 wallet_size = g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getWalletSize();
+
+        switch (wallet_size) {
+        case 0:
+            dComIfGs_setRupee(200);
+            break;
+        case 1:
+            dComIfGs_setRupee(1000);
+            break;
+        case 2:
+            dComIfGs_setRupee(5000);
+            break;
+        }
     }
 
     if (GZ_checkCheat(InfiniteArrows)) {

--- a/source/menus/amount_menu.cpp
+++ b/source/menus/amount_menu.cpp
@@ -1,5 +1,6 @@
 #include "controller.h"
 #include "menus/main_menu.h"
+#include "menus/quest_status_menu.h"
 #include "menus/amount_menu.h"
 #include "libtww/MSL_C/string.h"
 #include "libtww/d/com/d_com_inf_game.h"
@@ -44,10 +45,27 @@ void AmountMenu::draw() {
     u16 g_healthNum = dComIfGs_getLife();
     u8 g_bombNum = dComIfGs_getBombNum();
     u8 g_arrowNum = dComIfGs_getArrowNum();
-    u16 g_rupeeNum = dComIfGs_getRupee();
+    u16 g_rupeeNum = g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getRupee();
     u8 g_magicNum = dComIfGs_getMagic();
     u16 g_heartNum = dComIfGs_getMaxLife();
     u8 g_maxMagicNum = dComIfGs_getMaxMagic();
+    u8 g_walletSize = g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getWalletSize();
+
+    u16 max_rupees;
+    switch (g_walletSize) {
+    case WALLET_200:
+        max_rupees = 200;
+        break;
+    case WALLET_1000:
+        max_rupees = 1000;
+        break;
+    case WALLET_5000:
+        max_rupees = 5000;
+        break;
+    default:
+        max_rupees = 200;
+        break;
+    }
 
     if (GZ_getButtonTrig(GZPad::B)) {
         GZ_setMenu(GZ_INVENTORY_MENU);
@@ -96,12 +114,12 @@ void AmountMenu::draw() {
     case RUPEE_INDEX:
         Cursor::moveList(g_rupeeNum);
         if (g_rupeeNum == 0xFFFF) {
-            g_rupeeNum = 5000;
+            g_rupeeNum = max_rupees;
         }
-        if (g_rupeeNum > 5000) {
+        if (g_rupeeNum > max_rupees) {
             g_rupeeNum = 0;
         }
-        dComIfGs_setRupee(g_rupeeNum);
+        g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setRupee(g_rupeeNum);
         break;
     case MAGIC_INDEX:
         Cursor::moveList(g_magicNum);

--- a/source/menus/quest_status_menu.cpp
+++ b/source/menus/quest_status_menu.cpp
@@ -6,7 +6,7 @@
 #include "libtww/d/com/d_com_inf_game.h"
 #include "libtww/d/save/d_save.h"
 
-#define NUM_QUEST_ITEMS 25
+#define NUM_QUEST_ITEMS 26
 
 Cursor QuestStatusMenu::cursor;
 
@@ -14,6 +14,7 @@ Line lines[NUM_QUEST_ITEMS] = {
     {"Sword:", MENU_ITEM_SWORD, "Add/remove/upgrade sword"},
     {"Shield:", MENU_ITEM_SHIELD, "Add/remove/upgrade shield"},
     {"Magic:", MENU_ITEM_MAGIC, "Add/remove/upgrade magic"},
+    {"Wallet:", MENU_ITEM_WALLET, "Upgrade/downgrade wallet"},
     {"Quiver:", MENU_ITEM_QUIVER, "Add/remove/upgrade quiver"},
     {"Bomb Bag:", MENU_ITEM_BOMBAG, "Add/remove/upgrade bomb bag"},
     {"Power Bracelets:", MENU_ITEM_POWER_BRACELETS, "Add/remove power bracelets from inventory"},
@@ -101,7 +102,6 @@ const char* get_pearl_string(u8 pearls_owned, u8 pearl) {
     }
 }
 
-
 const char* get_magic_string(u8 magic_value) {
     if (magic_value == 0) {
         return "Empty";
@@ -109,6 +109,19 @@ const char* get_magic_string(u8 magic_value) {
         return "Double Magic";
     } else
         return "Single Magic";
+}
+
+const char* get_wallet_string(u8 wallet_size) {
+    switch (wallet_size) {
+    case WALLET_200:
+        return "Wallet 200";
+    case WALLET_1000:
+        return "Wallet 1000";
+    case WALLET_5000:
+        return "Wallet 5000";
+    default:
+        return "ERROR";
+    }
 }
 
 const char* get_quiver_string(u8 arrows_capacity) {
@@ -259,8 +272,9 @@ void QuestStatusMenu::draw() {
         return;
     }
 
-    u8 new_sword_item_id, new_shield_item_id, new_max_magic_value, new_arrows_capacity,new_bombs_capacity,new_power_bracelets_item_id,
-is_pirates_charm_owned, heros_charm_flag;
+    u8 new_sword_item_id, new_shield_item_id, new_max_magic_value, new_wallet_size,
+        new_arrows_capacity, new_bombs_capacity, new_power_bracelets_item_id,
+        is_pirates_charm_owned, heros_charm_flag;
 
     switch (cursor.y) {
     case MENU_ITEM_SWORD:
@@ -333,6 +347,26 @@ is_pirates_charm_owned, heros_charm_flag;
         }
         dComIfGs_setMagic(new_max_magic_value);
         dComIfGs_setMaxMagic(new_max_magic_value);
+        break;
+    case MENU_ITEM_WALLET:
+        new_wallet_size = g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getWalletSize();
+        Cursor::moveListSimple(new_wallet_size);
+        if (new_wallet_size == WALLET_200 - 1) {
+            new_wallet_size = WALLET_200;
+        } else if (new_wallet_size == WALLET_200 + 1) {
+            new_wallet_size = WALLET_1000;
+        } else if (new_wallet_size == WALLET_1000 - 1) {
+            new_wallet_size = WALLET_200;
+        } else if (new_wallet_size == WALLET_1000 + 1) {
+            new_wallet_size = WALLET_5000;
+        } else if (new_wallet_size == WALLET_5000 - 1) {
+            new_wallet_size = WALLET_1000;
+        } else if (new_wallet_size == WALLET_5000 + 1) {
+            new_wallet_size = WALLET_5000;
+        } else {
+            new_wallet_size = g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getWalletSize();
+        }
+        g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setWalletSize(new_wallet_size);
         break;
     case MENU_ITEM_POWER_BRACELETS:
         new_power_bracelets_item_id = dComIfGs_getPowerBracelets();
@@ -479,6 +513,8 @@ is_pirates_charm_owned, heros_charm_flag;
     tww_sprintf(lines[MENU_ITEM_SWORD].value, " <%s>", item_id_to_str(dComIfGs_getSword()));
     tww_sprintf(lines[MENU_ITEM_SHIELD].value, " <%s>", item_id_to_str(dComIfGs_getShield()));
     tww_sprintf(lines[MENU_ITEM_MAGIC].value, " <%s>", get_magic_string(dComIfGs_getMaxMagic()));
+    tww_sprintf(lines[MENU_ITEM_WALLET].value, " <%s>",
+                get_wallet_string(g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().getWalletSize()));
     tww_sprintf(lines[MENU_ITEM_QUIVER].value, " <%s>", get_quiver_string(dComIfGs_getArrowCapacity()));
     tww_sprintf(lines[MENU_ITEM_BOMBAG].value, " <%s>", get_bombags_string(dComIfGs_getBombCapacity()));
     tww_sprintf(lines[MENU_ITEM_POWER_BRACELETS].value, " <%s>",


### PR DESCRIPTION
This PR also improves the infinite rupee cheat, so it now sets the player's rupee count to their wallet's maximum rupee count instead of always 5000.  This stops the rupee count from ticking down from 5000 to 200 whenever spending money with the base wallet, for example.