### PR TITLE
Make -1 the default layer for practice saves

### DIFF
--- a/source/save_manager.cpp
+++ b/source/save_manager.cpp
@@ -45,7 +45,9 @@ void SaveManager::injectDefault_before() {
     g_dComIfG_gameInfo.play.mNextStage.wipe = 0;
 }
 
-void SaveManager::injectDefault_during() {}
+void SaveManager::injectDefault_during() {
+    g_dComIfG_gameInfo.play.mNextStage.setLayer(-1);
+}
 
 void SaveManager::injectDefault_after() {}
 


### PR DESCRIPTION
The layer should be manually overridden for every practice save to ensure the layer is correct for every practice save.