### PR TITLE
Cleanup Dockerfile used by devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,11 @@ USER vscode
 RUN sudo dpkg --add-architecture i386
 RUN sudo apt-get update
 RUN sudo apt-get install -y clang-format-10
+RUN sudo apt-get install -y python3-pip
 RUN sudo apt-get install -y cmake
 RUN sudo apt-get install -y ninja-build
+
+RUN python3 -m pip install Pillow
 
 # Install DevkitPPC
 RUN sudo ln -sf /proc/self/mounts /etc/mtab

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,27 +1,14 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/ubuntu/.devcontainer/base.Dockerfile
 
-# [Choice] Ubuntu version (use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon): ubuntu-22.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT="jammy"
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 USER vscode
 
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
 RUN sudo dpkg --add-architecture i386
-RUN sudo apt-get update && sudo apt-get install -y build-essential
-RUN sudo apt-get install -y python3-pip
-RUN sudo apt-get install -y libarchive-tools 
+RUN sudo apt-get update
 RUN sudo apt-get install -y clang-format-10
 RUN sudo apt-get install -y cmake
-# RUN sudo apt-get install -y wine64
-# RUN sudo apt-get install -y wine
 RUN sudo apt-get install -y ninja-build
-RUN sudo apt-get upgrade -y
-RUN sudo apt-get install -y libtinfo5
-
-RUN python3 -m pip install Pillow
 
 # Install DevkitPPC
 RUN sudo ln -sf /proc/self/mounts /etc/mtab
@@ -32,12 +19,4 @@ RUN sudo ./install-devkitpro-pacman
 RUN sudo dkp-pacman -Syu --noconfirm
 WORKDIR /etc
 RUN sudo ln -sf /proc/self/mounts mtab
-RUN sudo dkp-pacman -S --noconfirm gamecube-dev wii-dev
-
-# # Install the patchers
-# WORKDIR /workspaces/romhack/wii
-# RUN curl -L https://github.com/zsrtp/romhack-compiler/releases/download/v0.1.1-r2/romhack-v0.1.1-r2-linux-x64-musl.zip | bsdtar -xvf -
-# RUN chmod +x romhack
-# WORKDIR /workspaces/romhack/gc
-# RUN curl -L https://github.com/zsrtp/romhack-compiler/releases/download/v0.1.1-r2/romhack-v0.1.1-r2-linux-x64-musl-gc.zip | bsdtar -xvf -
-# RUN chmod +x romhack
+RUN sudo dkp-pacman -S --noconfirm gamecube-dev


### PR DESCRIPTION
This removes alot of steps from the devcontainer that don't seem to be necessary. Alot of it comes from the tpgz version of the container Im sure, which has more requirements.

Skipping out on `sudo apt-get upgrade` inside the container may be considered bad practice, but at least for me, this makes setting up the container take a very long time. It reduces setup time from something like 10 minutes to about 1-2 minutes. 
Things seem to work fine without upgrading the OS, so I think its fine to not worry about it.