### PR TITLE
Set up Github Actions to build all versions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.sha }}-${{ matrix.version_lower }}.patch
-        path: build_${{ matrix.version_lower }}/0.4.0-${{ matrix.version_lower }}.patch
+        path: build-${{ matrix.version_lower }}/0.4.0-${{ matrix.version_lower }}.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+    DEVKITPRO: /opt/devkitpro
+
 permissions:
   contents: read
   packages: read
@@ -30,12 +33,12 @@ jobs:
         cp -R /isos isos
         cp /clang-format-10 external/misc/clang-format-10
         
-        - name: Setup
-        run: | 
-        export DEVKITPRO=/opt/devkitpro
+    - name: Setup
+      run: | 
         mkdir -p build_${{matrix.version}}
         cd build_${{matrix.version}}
-        cmake .. -DREGION=$(echo ${{matrix.version}} | tr '[:lower:]' '[:upper:]') -GNinja
+        echo "REGION_U=${${{matrix.version}}@U}" >> "${GITHUB_ENV}"
+        cmake .. -DREGION=$(echo ${REGION_U} | tr '[:lower:]' '[:upper:]') -GNinja
     
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
             - version_upper: NTSCJ
-              version_lower: ntsj
+              version_lower: ntscj
         
     
     name: ${{matrix.version_upper}}
@@ -53,4 +53,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.sha }}-${{ matrix.version_lower }}.patch
-        path: build-${{ matrix.version_lower }}/0.4.0-${{ matrix.version_lower }}.patch
+        path: build_${{ matrix.version_lower }}/0.4.0-${{ matrix.version_lower }}.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,13 @@ jobs:
             # The build system uses lower case and upper case in different areas
             # and its invonvenient to change strings between upper and lower in github actions shell commands.
             # So, just store both as a pair.
+            # Ideally at some point we remove this inconsistency in the build system and just use uppercase always.
             - version_upper: NTSCJ
               version_lower: ntscj
             - version_upper: NTSCU
               version_lower: ntscu
+            - version_upper: PAL
+              version_lower: pal
         
     
     name: ${{matrix.version_upper}}
@@ -57,5 +60,5 @@ jobs:
     - name: Upload patch
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ matrix.version_lower }}-${{ github.sha }}.patch
+        name: ${{ matrix.version_upper }}-${{ github.sha }}.patch
         path: build_${{ matrix.version_lower }}/${{ matrix.version_lower }}.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,50 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+  packages: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/zsrtww/tww-gz-build:main
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [GZLJ01]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Git config
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    - name: Prepare
+      run: |
+        cp -R /isos isos
+        cp /clang-format-10 external/misc/clang-format-10
+        export DEVKITPRO=/opt/devkitpro
+    
+    - name: Setup
+      run: | 
+        mkdir -p build_${{matrix.version}}
+        pushd build_${{matrix.version}}
+        cmake .. -DREGION=$(echo ${{matrix.version}} | tr '[:lower:]' '[:upper:]') -GNinja
+        popd
+    
+    - name: Build
+      run: |
+        pushd build_${{matrix.version}}
+        ninja patch
+
+    - name: Upload patch
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.sha }}-${{ matrix.version }}.patch
+        path: build_${{ matrix.version }}/0.4.0-${{ matrix.version }}.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
 name: Build All
 
 on:
-  push:
-  pull_request:
+    push:
+      branches: [ main ]
+    pull_request:
+      branches: [ main ]
 
 env:
     DEVKITPRO: /opt/devkitpro

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [GZLJ01]
+        version: [ntscj]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
       run: |
         cp -R /isos isos
         cp /clang-format-10 external/misc/clang-format-10
+        
+        - name: Setup
+        run: | 
         export DEVKITPRO=/opt/devkitpro
-    
-    - name: Setup
-      run: | 
         mkdir -p build_${{matrix.version}}
         cd build_${{matrix.version}}
         cmake .. -DREGION=$(echo ${{matrix.version}} | tr '[:lower:]' '[:upper:]') -GNinja

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build All
 
 on:
   push:
@@ -20,7 +20,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [NTSCJ]
+        include:
+            - version_upper: NTSCJ
+              version_lower: ntsj
+        
+    
+    name: ${{matrix.version_upper}}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -33,19 +38,19 @@ jobs:
         cp -R /isos isos
         cp /clang-format-10 external/misc/clang-format-10
         
-    - name: Setup 1
+    - name: Setup
       run: |
-        mkdir -p build_${{matrix.version}}
-        cd build_${{matrix.version}}
-        cmake .. -DREGION=${{matrix.version}} -GNinja
+        mkdir -p build_${{matrix.version_lower}}
+        cd build_${{matrix.version_lower}}
+        cmake .. -DREGION=${{matrix.version_upper}} -GNinja
     
     - name: Build
       run: |
-        cd build_${{matrix.version}}
+        cd build_${{matrix.version_lower}}
         ninja patch
 
     - name: Upload patch
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ github.sha }}-${{ matrix.version }}.patch
-        path: build_${{ matrix.version }}/0.4.0-${{ matrix.version }}.patch
+        name: ${{ github.sha }}-${{ matrix.version_lower }}.patch
+        path: build_${{ matrix.version_lower }}/0.4.0-${{ matrix.version_lower }}.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ntscj]
+        version: [NTSCJ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -38,9 +38,7 @@ jobs:
     - name: Setup 2
       run: cd build_${{matrix.version}}
     - name: Setup 3
-      run: echo "REGION_U=${${{matrix.version}}@U}" >> "${GITHUB_ENV}"
-    - name: Setup 4
-      run: cmake .. -DREGION=$(echo ${REGION_U} | tr '[:lower:]' '[:upper:]') -GNinja
+      run: cmake .. -DREGION=${{matrix.version}} -GNinja
     
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,14 @@ jobs:
         cp -R /isos isos
         cp /clang-format-10 external/misc/clang-format-10
         
-    - name: Setup
-      run: | 
-        mkdir -p build_${{matrix.version}}
-        cd build_${{matrix.version}}
-        echo "REGION_U=${${{matrix.version}}@U}" >> "${GITHUB_ENV}"
-        cmake .. -DREGION=$(echo ${REGION_U} | tr '[:lower:]' '[:upper:]') -GNinja
+    - name: Setup 1
+      run: mkdir -p build_${{matrix.version}}
+    - name: Setup 2
+      run: cd build_${{matrix.version}}
+    - name: Setup 3
+      run: echo "REGION_U=${${{matrix.version}}@U}" >> "${GITHUB_ENV}"
+    - name: Setup 4
+      run: cmake .. -DREGION=$(echo ${REGION_U} | tr '[:lower:]' '[:upper:]') -GNinja
     
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+            # The build system uses lower case and upper case in different areas
+            # and its invonvenient to change strings between upper and lower in github actions shell commands.
+            # So, just store both as a pair.
             - version_upper: NTSCJ
               version_lower: ntscj
             - version_upper: NTSCU
@@ -54,5 +57,5 @@ jobs:
     - name: Upload patch
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ github.sha }}-${{ matrix.version_lower }}.patch
-        path: build_${{ matrix.version_lower }}/0.4.0-${{ matrix.version_lower }}.patch
+        name: ${{ matrix.version_lower }}-${{ github.sha }}.patch
+        path: build_${{ matrix.version_lower }}/${{ matrix.version_lower }}.patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,12 @@ jobs:
     - name: Setup
       run: | 
         mkdir -p build_${{matrix.version}}
-        pushd build_${{matrix.version}}
+        cd build_${{matrix.version}}
         cmake .. -DREGION=$(echo ${{matrix.version}} | tr '[:lower:]' '[:upper:]') -GNinja
-        popd
     
     - name: Build
       run: |
-        pushd build_${{matrix.version}}
+        cd build_${{matrix.version}}
         ninja patch
 
     - name: Upload patch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,10 @@ jobs:
         cp /clang-format-10 external/misc/clang-format-10
         
     - name: Setup 1
-      run: mkdir -p build_${{matrix.version}}
-    - name: Setup 2
-      run: cd build_${{matrix.version}}
-    - name: Setup 3
-      run: cmake .. -DREGION=${{matrix.version}} -GNinja
+      run: |
+        mkdir -p build_${{matrix.version}}
+        cd build_${{matrix.version}}
+        cmake .. -DREGION=${{matrix.version}} -GNinja
     
     - name: Build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
         include:
             - version_upper: NTSCJ
               version_lower: ntscj
+            - version_upper: NTSCU
+              version_lower: ntscu
         
     
     name: ${{matrix.version_upper}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${TWWGZ_CFG_BLD_ISO}
 string(REPLACE ".iso" ".patch" TWWGZ_CFG_BLD_PATCH_OLD ${TWWGZ_CFG_BLD_ISO})
 string(TOLOWER ${REGION} twwgz_region_lower)
 string(REPLACE "_" "-" twwgz_region_lower ${twwgz_region_lower})
-set(TWWGZ_CFG_BLD_PATCH ${CMAKE_PROJECT_VERSION}-${twwgz_region_lower}.patch)
+set(TWWGZ_CFG_BLD_PATCH ${twwgz_region_lower}.patch)
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${TWWGZ_CFG_BLD_PATCH}
     DEPENDS twwgz modules ${TWWGZ_PATCHER_EXE} ${CMAKE_CURRENT_SOURCE_DIR}/res ${CMAKE_CURRENT_BINARY_DIR}/patch.asm ${CMAKE_CURRENT_BINARY_DIR}/RomHack.toml ${TWWGZ_REL_FILES}
     COMMAND ${TWWGZ_PATCHER_EXE} build --raw --patch


### PR DESCRIPTION
Github actions will now build all 3 versions on all pull requests and every main branch merge.
A patch file is uploaded as an artifact, which can be downloaded by anyone for testing purposes.