### PR TITLE
updated patcher & removed dummy lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/isos)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
 # Set compiler stuff
-include_directories(include external)
+include_directories(external)
 add_definitions(-D${REGION} -DGZ_VERSION=${CMAKE_PROJECT_VERSION} -D_PROJECT_NAME="${CMAKE_PROJECT_NAME}" -D_VERSION="${CMAKE_PROJECT_VERSION}" -D_VARIANT="public" -D_BUILDID="${CMAKE_PROJECT_VERSION}" ${DEBUG} ${RUN_PR_TEST})
 add_compile_options(-fdiagnostics-color=always -fvisibility=hidden)
 
@@ -74,10 +74,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/RomHack.toml.in ${CMAKE_CURRENT_BINAR
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
-add_subdirectory(src)
 add_subdirectory(modules)
 
-add_library(twwgz STATIC "${CPPFILES}")
+add_custom_target(twwgz ALL)
 add_dependencies(twwgz tww_c gcn_c modules)
 set_property(TARGET twwgz PROPERTY COMPILE_FLAGS "-g -c -Oz -std=gnu++20 -Wall ${DEVKITPRO_MACHDEP}")
 

--- a/RomHack.toml.in
+++ b/RomHack.toml.in
@@ -13,11 +13,6 @@ map = "@TWWGZ_CFG_SRC_MAP@"
 map = "@TWWGZ_CFG_BLD_MAP@"
 iso = "@TWWGZ_CFG_BLD_ISO@"
 
-[link]
-entries = ["apply_lib_hooks"]
-base = "@TWWGZ_CFG_LINK_BASE@"
-libs = ["libtwwgz.a"]
-
 [files]
 # textures
 "twwgz/tex" = "../res/tex"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,0 @@
-# IMPORTANT: if you add/remove a source file that has to be compiled, add it
-# manually instead of automatically searching for it (as mentioned in the note
-# of the "Filesystem" section of
-# https://cmake.org/cmake/help/latest/command/file.html#filesystem)
-file(GLOB_RECURSE CPPFILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
-
-set(CPPFILES ${CPPFILES} PARENT_SCOPE)

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -1,3 +1,0 @@
-extern "C" {
-void apply_lib_hooks() {}
-}


### PR DESCRIPTION
This updates the patcher to an updated version which doesn't require to have a dummy library.

**Warning**
If you accept this PR and start using the new patcher, the users will have to use the [updated patcher](https://github.com/zsrtp/geckopatcher/releases/tag/v0.1.0-alpha) as well to apply the romhack, since the old romhack-compiler one still needs a dummy library to patch an ISO.