### PR TITLE
Create "ActorMoveManager"

### DIFF
--- a/external/libtww/include/d/a/d_a_player_main.h
+++ b/external/libtww/include/d/a/d_a_player_main.h
@@ -9,6 +9,7 @@
 #include "../bg/d_bg_s_acch.h"
 #include "../bg/d_bg_s_lin_chk.h"
 #include "../cc/d_cc_d.h"
+#include "../com/d_com_inf_game.h"
 
 class mDoExt_MtxCalcOldFrame;
 class mDoExt_McaMorf;

--- a/external/libtww/include/f_op/f_op_actor_iter.h
+++ b/external/libtww/include/f_op/f_op_actor_iter.h
@@ -1,0 +1,26 @@
+#ifndef F_OP_ACTOR_ITER_H_
+#define F_OP_ACTOR_ITER_H_
+
+#include "libtww/include/defines.h"
+
+#include "f_op_actor.h"
+#include "../defines.h"
+
+typedef void* (*fopAcIt_JudgeFunc)(void*, void*);
+
+
+#define fpcSch_JudgeForPName fpcSch_JudgeForPName__FPvPv
+
+extern "C" {
+void* fpcSch_JudgeForPName(void*, void*);
+}
+
+LIBTWW_DEFINE_FUNC(fopAcIt_Judge__FPFPvPv_PvPv, void*, fopAcIt_Judge, (fopAcIt_JudgeFunc, void*))
+
+extern "C" {
+inline void* fopAcM_SearchByName(s16 name) {
+    return fopAcIt_Judge(fpcSch_JudgeForPName, &name);
+}
+}
+
+#endif

--- a/external/libtww/include/f_op/f_op_actor_mng.h
+++ b/external/libtww/include/f_op/f_op_actor_mng.h
@@ -2,7 +2,9 @@
 #define F_OP_ACTOR_MNG_H_
 
 #include "f_op_actor.h"
+#include "f_op_actor_iter.h"
 #include "../f_pc/f_pc_manager.h"
+#include "../f_pc/f_pc_searcher.h"
 
 struct fopAcM_prmBase_class {
     /* 0x00 */ u32 field_0x00;

--- a/external/libtww/include/f_pc/f_pc_searcher.h
+++ b/external/libtww/include/f_pc/f_pc_searcher.h
@@ -1,0 +1,11 @@
+
+#ifndef F_PC_SEARCHER_H_
+#define F_PC_SEARCHER_H_
+
+#include "libtww/include/defines.h"
+
+LIBTWW_DEFINE_FUNC(fpcSch_JudgeForPName__FPvPv, void*, fpcSch_JudgeForPName, (void*, void*))
+
+void* fpcSch_JudgeByID(void* pProc, void* pUserData);
+
+#endif

--- a/modules/boot/include/actor_move_manager.h
+++ b/modules/boot/include/actor_move_manager.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <boot/include/utils/containers/deque.h>
+#include "libtww/include/dolphin/mtx/vec.h"
+#include "libtww/include/dolphin/gctypes.h"
+
+typedef enum {
+    ACTORMOVE_POS_YAW,
+    ACTORMOVE_POS,
+} ActorMoveType;
+
+struct ActorMoveEntry {
+    u32 id;
+    u16 attempts;
+    s16 procName;
+    Vec pos;
+    s16 yaw;
+    ActorMoveType type;
+};
+
+class ActorMoveManager {
+public:
+    inline void SetPosYaw(s16 procName, f32 x, f32 y, f32 z, s16 yaw) {
+        AddRequest(procName, x, y, z, yaw, ACTORMOVE_POS_YAW);
+    }
+
+    inline void SetPos(s16 procName, f32 x, f32 y, f32 z) {
+        AddRequest(procName, x, y, z, 0, ACTORMOVE_POS);
+    }
+
+    void ProcessRequests();
+    
+private:
+    u32 mCurId;
+    twwgz::containers::deque<ActorMoveEntry> mDeque;
+
+    void AddRequest(s16 procName, f32 x, f32 y, f32 z, s16 yRot, ActorMoveType type);
+    void RemoveRequest(u32 id);
+    bool TryMovingActor(ActorMoveEntry entry);
+};
+
+extern ActorMoveManager gActorMoveMgr;

--- a/modules/boot/include/actor_move_manager.h
+++ b/modules/boot/include/actor_move_manager.h
@@ -38,7 +38,6 @@ private:
 
     void AddRequest(s16 procName, f32 x, f32 y, f32 z, s16 yRot, ActorMoveType type);
     void RemoveRequest(u32 id);
-    fopAc_ac_c* CheckForActor(ActorMoveEntry entry);
     void MoveActor(ActorMoveEntry entry);
 };
 

--- a/modules/boot/include/actor_move_manager.h
+++ b/modules/boot/include/actor_move_manager.h
@@ -3,6 +3,7 @@
 #include <boot/include/utils/containers/deque.h>
 #include "libtww/include/dolphin/mtx/vec.h"
 #include "libtww/include/dolphin/gctypes.h"
+#include "libtww/include/f_op/f_op_actor.h"
 
 typedef enum {
     ACTORMOVE_POS_YAW,
@@ -16,6 +17,7 @@ struct ActorMoveEntry {
     Vec pos;
     s16 yaw;
     ActorMoveType type;
+    fopAc_ac_c* actor;
 };
 
 class ActorMoveManager {
@@ -36,7 +38,8 @@ private:
 
     void AddRequest(s16 procName, f32 x, f32 y, f32 z, s16 yRot, ActorMoveType type);
     void RemoveRequest(u32 id);
-    bool TryMovingActor(ActorMoveEntry entry);
+    fopAc_ac_c* CheckForActor(ActorMoveEntry entry);
+    void MoveActor(ActorMoveEntry entry);
 };
 
 extern ActorMoveManager gActorMoveMgr;

--- a/modules/boot/include/actor_move_manager.h
+++ b/modules/boot/include/actor_move_manager.h
@@ -26,12 +26,10 @@ public:
         AddRequest(procName, x, y, z, yaw, ACTORMOVE_POS_YAW);
     }
 
-    inline void SetPos(s16 procName, f32 x, f32 y, f32 z) {
-        AddRequest(procName, x, y, z, 0, ACTORMOVE_POS);
-    }
+    inline void SetPos(s16 procName, f32 x, f32 y, f32 z) { AddRequest(procName, x, y, z, 0, ACTORMOVE_POS); }
 
     void ProcessRequests();
-    
+
 private:
     u32 mCurId;
     twwgz::containers::deque<ActorMoveEntry> mDeque;

--- a/modules/boot/include/boot.h
+++ b/modules/boot/include/boot.h
@@ -26,6 +26,7 @@ void GZ_handleMenu();
 void GZ_renderMenuTitle();
 void GZ_displaySplash();
 void GZ_endlessNightOnTitle();
+void GZ_updateActorMoveMgr();
 void GZ_handleFlags_PreLoop();
 void GZ_handleFlags_PostLoop();
 

--- a/modules/boot/src/actor_move_manager.cpp
+++ b/modules/boot/src/actor_move_manager.cpp
@@ -35,11 +35,6 @@ KEEP_FUNC void ActorMoveManager::MoveActor(ActorMoveEntry entry) {
             l_debug_keep_pos.z = entry.pos.z;
         }
     }
-    
-}
-
-KEEP_FUNC fopAc_ac_c* ActorMoveManager::CheckForActor(ActorMoveEntry entry) {
-    return (fopAc_ac_c*)fopAcM_SearchByName(entry.procName);
 }
 
 KEEP_FUNC void ActorMoveManager::ProcessRequests() {
@@ -53,10 +48,12 @@ KEEP_FUNC void ActorMoveManager::ProcessRequests() {
             return;
         }
 
-        // Separating the check and set phases introduces a purposeful 1 frame delay.
-        // This is necessary, for whatever reason, for 
+        // Separating the "actor check" and "actor move" phases induces a purposeful
+        // 1 frame delay between these two steps.
+        // For whatever reason, this is necessary in some cases to allow for moving an actor's 
+        // position. I wish I knew why.
         if (req->actor == nullptr) {
-            req->actor = CheckForActor(*req);
+            req->actor = (fopAc_ac_c*)fopAcM_SearchByName(req->procName);
         } else {
             MoveActor(*req);
         }

--- a/modules/boot/src/actor_move_manager.cpp
+++ b/modules/boot/src/actor_move_manager.cpp
@@ -1,12 +1,13 @@
 #include "actor_move_manager.h"
+#include "libtww/include/d/d_procname.h"
+#include "libtww/include/d/a/d_a_player_main.h"
 #include "libtww/include/f_op/f_op_actor_iter.h"
-#include "libtww/include/f_op/f_op_actor.h"
 #include "libtww/include/m_Do/m_Do_printf.h"
 
 KEEP_VAR ActorMoveManager gActorMoveMgr;
 
 KEEP_FUNC void ActorMoveManager::AddRequest(s16 procName, f32 x, f32 y, f32 z, s16 yaw, ActorMoveType type) {
-    mDeque.push_back({mCurId, 0, procName, {x, y, z}, yaw, type});
+    mDeque.push_back({mCurId, 0, procName, {x, y, z}, yaw, type, nullptr});
     mCurId++;
 }
 
@@ -18,37 +19,46 @@ KEEP_FUNC void ActorMoveManager::RemoveRequest(u32 id) {
     }
 }
 
-KEEP_FUNC bool ActorMoveManager::TryMovingActor(ActorMoveEntry entry) {
-    fopAc_ac_c* actor = (fopAc_ac_c*)fopAcM_SearchByName(entry.procName);
+KEEP_FUNC void ActorMoveManager::MoveActor(ActorMoveEntry entry) {
+    fopAc_ac_c* actor = entry.actor;
 
-    // If actor is NULL at this point, the actor doesn't exist yet and may still be creating
-    if (actor != nullptr) {
-        switch (entry.type) {
-        case ACTORMOVE_POS_YAW:
-            actor->current.angle.y = actor->shape_angle.y = entry.yaw;
-            // FALLTHROUGH
-        case ACTORMOVE_POS:
-            actor->current.pos.set(entry.pos.x, entry.pos.y, entry.pos.z);
+    switch (entry.type) {
+    case ACTORMOVE_POS_YAW:
+        actor->current.angle.y = actor->shape_angle.y = entry.yaw;
+        // FALLTHROUGH
+    case ACTORMOVE_POS:
+        actor->current.pos.set(entry.pos.x, entry.pos.y, entry.pos.z);
+
+        if (entry.procName == PROC_PLAYER) {
+            l_debug_keep_pos.x = entry.pos.x;
+            l_debug_keep_pos.y = entry.pos.y;
+            l_debug_keep_pos.z = entry.pos.z;
         }
-
-        return true;
     }
+    
+}
 
-    return false;
+KEEP_FUNC fopAc_ac_c* ActorMoveManager::CheckForActor(ActorMoveEntry entry) {
+    return (fopAc_ac_c*)fopAcM_SearchByName(entry.procName);
 }
 
 KEEP_FUNC void ActorMoveManager::ProcessRequests() {
     for (auto req = mDeque.begin(); req != mDeque.end(); ++req) {
-        if (TryMovingActor(*req)) {
-            RemoveRequest(req->id);
-        } else {
-            req->attempts++;
+        req->attempts++;
 
-            // Dont allow attempts to last longer than 5 seconds
-            if (req->attempts >= 150) {
-                OSReport("Couldn't find actor:%d, deleting move request:%d\n", req->procName, req->id);
-                RemoveRequest(req->id);
-            }
+        // Dont allow attempts to last longer than 5 seconds
+        if (req->attempts >= 150) {
+            OSReport("Couldn't find actor:%d, deleting move request:%d\n", req->procName, req->id);
+            RemoveRequest(req->id);
+            return;
+        }
+
+        // Separating the check and set phases introduces a purposeful 1 frame delay.
+        // This is necessary, for whatever reason, for 
+        if (req->actor == nullptr) {
+            req->actor = CheckForActor(*req);
+        } else {
+            MoveActor(*req);
         }
     }   
 }

--- a/modules/boot/src/actor_move_manager.cpp
+++ b/modules/boot/src/actor_move_manager.cpp
@@ -50,12 +50,12 @@ KEEP_FUNC void ActorMoveManager::ProcessRequests() {
 
         // Separating the "actor check" and "actor move" phases induces a purposeful
         // 1 frame delay between these two steps.
-        // For whatever reason, this is necessary in some cases to allow for moving an actor's 
+        // For whatever reason, this is necessary in some cases to allow for moving an actor's
         // position. I wish I knew why.
         if (req->actor == nullptr) {
             req->actor = (fopAc_ac_c*)fopAcM_SearchByName(req->procName);
         } else {
             MoveActor(*req);
         }
-    }   
+    }
 }

--- a/modules/boot/src/actor_move_manager.cpp
+++ b/modules/boot/src/actor_move_manager.cpp
@@ -1,0 +1,54 @@
+#include "actor_move_manager.h"
+#include "libtww/include/f_op/f_op_actor_iter.h"
+#include "libtww/include/f_op/f_op_actor.h"
+#include "libtww/include/m_Do/m_Do_printf.h"
+
+KEEP_VAR ActorMoveManager gActorMoveMgr;
+
+KEEP_FUNC void ActorMoveManager::AddRequest(s16 procName, f32 x, f32 y, f32 z, s16 yaw, ActorMoveType type) {
+    mDeque.push_back({mCurId, 0, procName, {x, y, z}, yaw, type});
+    mCurId++;
+}
+
+KEEP_FUNC void ActorMoveManager::RemoveRequest(u32 id) {
+    for (auto req = mDeque.begin(); req != mDeque.end(); ++req) {
+        if (req->id == id) {
+            mDeque.erase(req);
+        }
+    }
+}
+
+KEEP_FUNC bool ActorMoveManager::TryMovingActor(ActorMoveEntry entry) {
+    fopAc_ac_c* actor = (fopAc_ac_c*)fopAcM_SearchByName(entry.procName);
+
+    // If actor is NULL at this point, the actor doesn't exist yet and may still be creating
+    if (actor != nullptr) {
+        switch (entry.type) {
+        case ACTORMOVE_POS_YAW:
+            actor->current.angle.y = actor->shape_angle.y = entry.yaw;
+            // FALLTHROUGH
+        case ACTORMOVE_POS:
+            actor->current.pos.set(entry.pos.x, entry.pos.y, entry.pos.z);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+KEEP_FUNC void ActorMoveManager::ProcessRequests() {
+    for (auto req = mDeque.begin(); req != mDeque.end(); ++req) {
+        if (TryMovingActor(*req)) {
+            RemoveRequest(req->id);
+        } else {
+            req->attempts++;
+
+            // Dont allow attempts to last longer than 5 seconds
+            if (req->attempts >= 150) {
+                OSReport("Couldn't find actor:%d, deleting move request:%d\n", req->procName, req->id);
+                RemoveRequest(req->id);
+            }
+        }
+    }   
+}

--- a/modules/boot/src/main.cpp
+++ b/modules/boot/src/main.cpp
@@ -21,6 +21,7 @@
 #include "events/draw_listener.h"
 #include "events/pre_loop_listener.h"
 #include "events/post_loop_listener.h"
+#include "actor_move_manager.h"
 
 #define isWidescreen (false)
 
@@ -211,4 +212,8 @@ KEEP_FUNC void GZ_endlessNightOnTitle() {
     g_env_light.mColpatCurr = 1;
     g_env_light.mThunderEff.mMode = 1;
     g_env_light.mRainCount = 250;
+}
+
+KEEP_FUNC void GZ_updateActorMoveMgr() {
+    gActorMoveMgr.ProcessRequests();
 }

--- a/modules/boot/src/save_specials.cpp
+++ b/modules/boot/src/save_specials.cpp
@@ -36,7 +36,7 @@ KEEP_FUNC void SaveMngSpecial_Windfall_Day0() {
 KEEP_FUNC void SaveMngSpecial_BombsSwim_After() {
     gSaveManager.injectDefault_after();
 
-    // Set KorL's pos and angle to be the same as when the Wind Waker cutscene ends
+    // Set KoRL's pos and angle to be the same as when the Wind Waker cutscene ends
     gActorMoveMgr.SetPosYaw(PROC_SHIP, 196459.0f, 0.0f, -199693.0f, 0x623E);
 }
 
@@ -78,7 +78,6 @@ KEEP_FUNC void SaveMngSpecial_TrialsSkip_After() {
     gSaveManager.injectDefault_after();
     g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setLife(6);
     g_dComIfG_gameInfo.info.getPlayer().getItemRecord().setBombNum(17);
-    gActorMoveMgr.SetPosYaw(PROC_PLAYER, -6.0f, 750.0f, -8700.0f, 0x4000);
 }
 
 KEEP_FUNC void SaveMngSpecial_PuppetGanon() {

--- a/modules/boot/src/save_specials.cpp
+++ b/modules/boot/src/save_specials.cpp
@@ -78,7 +78,7 @@ KEEP_FUNC void SaveMngSpecial_TrialsSkip_After() {
     gSaveManager.injectDefault_after();
     g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setLife(6);
     g_dComIfG_gameInfo.info.getPlayer().getItemRecord().setBombNum(17);
-    gActorMoveMgr.SetPosYaw(PROC_PLAYER, 25.0f, 943.0f, -5143.0f, 0x0);
+    gActorMoveMgr.SetPosYaw(PROC_PLAYER, -6.0f, 750.0f, -8700.0f, 0x4000);
 }
 
 KEEP_FUNC void SaveMngSpecial_PuppetGanon() {

--- a/modules/boot/src/save_specials.cpp
+++ b/modules/boot/src/save_specials.cpp
@@ -1,9 +1,11 @@
 #include "libtww/include/d/com/d_com_inf_game.h"
 #include "libtww/include/d/com/d_com_static.h"
+#include "libtww/include/d/d_procname.h"
 
 #include "flags.h"
 #include "save_manager.h"
 #include "save_specials.h"
+#include "actor_move_manager.h"
 #include "rels/include/defines.h"
 
 KEEP_FUNC void SaveMngSpecial_ForestOfFairies_FirstVisit() {
@@ -34,13 +36,8 @@ KEEP_FUNC void SaveMngSpecial_Windfall_Day0() {
 KEEP_FUNC void SaveMngSpecial_BombsSwim_After() {
     gSaveManager.injectDefault_after();
 
-    fopAc_ac_c* ship_p = g_dComIfG_gameInfo.play.mpPlayerPtr[2];
-
-    if (ship_p != nullptr) {
-        // set KorL's pos and angle to be the same as when the Wind Waker cutscene ends
-        ship_p->current.pos.set(196459.0f, 0.0f, -199693.0f);
-        ship_p->current.angle.y = ship_p->shape_angle.y = 0x623E;
-    }
+    // Set KorL's pos and angle to be the same as when the Wind Waker cutscene ends
+    gActorMoveMgr.SetPosYaw(PROC_SHIP, 196459.0f, 0.0f, -199693.0f, 0x623E);
 }
 
 KEEP_FUNC void SaveMngSpecial_DTCS() {
@@ -81,6 +78,7 @@ KEEP_FUNC void SaveMngSpecial_TrialsSkip_After() {
     gSaveManager.injectDefault_after();
     g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setLife(6);
     g_dComIfG_gameInfo.info.getPlayer().getItemRecord().setBombNum(17);
+    gActorMoveMgr.SetPosYaw(PROC_PLAYER, 25.0f, 943.0f, -5143.0f, 0x0);
 }
 
 KEEP_FUNC void SaveMngSpecial_PuppetGanon() {

--- a/modules/boot/src/utils/hook.cpp
+++ b/modules/boot/src/utils/hook.cpp
@@ -28,7 +28,6 @@ HOOK_DEF(int, dScnPly_Draw, (void*));
 HOOK_DEF(void, putSave, (void*, int));
 HOOK_DEF(int, dScnPly__phase_1, (void*));
 HOOK_DEF(int, dScnPly__phase_4, (void*));
-HOOK_DEF(int, dScnPly__phase_compleate, (void*));
 HOOK_DEF(int, dScnPly_Delete, (void*));
 HOOK_DEF(void, setDaytime, (void*));
 HOOK_DEF(void, BeforeOfPaint, (void));
@@ -78,25 +77,13 @@ int dScnPly__phase_1Hook(void* i_scene) {
 int dScnPly__phase_4Hook(void* i_scene) {
     int ret = dScnPly__phase_4Trampoline(i_scene);
 
-    // Only apply the `after` options now if phase 4 indicates the loading proccess is complete.
-    // If the rest of the phases need to run, the options will be applied later in
-    // `dScnPly__phase_compleate`.
-    if (ret == cPhs_COMPLEATE_e) {
-        SaveManager::applyAfterOptions();
-    }
+    SaveManager::applyAfterOptions();
 
     if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE) {
         g_PreLoopListener->addListener(GZ_endlessNightOnTitle);
     }
 
     return ret;
-}
-
-int dScnPly__phase_compleateHook(void* i_scene) {
-    // If execution reaches this point, it means that the loading process did not exit early in
-    // `dScnPly__phase_4`. So, apply the `after` options now.
-    SaveManager::applyAfterOptions();
-    return dScnPly__phase_compleateTrampoline(i_scene);
 }
 
 int dScnPly_DeleteHook(void* i_scene) {
@@ -175,7 +162,6 @@ int dScnPly_Draw__FP13dScnPly_ply_c(void*);
 void putSave__10dSv_info_cFi(void*, int);
 int phase_1__FP13dScnPly_ply_c(void*);
 int phase_4__FP13dScnPly_ply_c(void*);
-int phase_compleate__FPv(void*);
 int dScnPly_Delete__FP13dScnPly_ply_c(void*);
 void setDaytime__18dScnKy_env_light_cFv(void*);
 void dScnPly_BeforeOfPaint__Fv();
@@ -195,7 +181,6 @@ KEEP_FUNC void applyHooks() {
     APPLY_HOOK(putSave, &putSave__10dSv_info_cFi, putSaveHook);
     APPLY_HOOK(dScnPly__phase_1, &phase_1__FP13dScnPly_ply_c, dScnPly__phase_1Hook);
     APPLY_HOOK(dScnPly__phase_4, &phase_4__FP13dScnPly_ply_c, dScnPly__phase_4Hook);
-    APPLY_HOOK(dScnPly__phase_compleate, &phase_compleate__FPv, dScnPly__phase_compleateHook);
     APPLY_HOOK(dScnPly_Delete, &dScnPly_Delete__FP13dScnPly_ply_c, dScnPly_DeleteHook);
     APPLY_HOOK(setDaytime, &setDaytime__18dScnKy_env_light_cFv, setDaytimeHook);
     APPLY_HOOK(BeforeOfPaint, &dScnPly_BeforeOfPaint__Fv, beforeOfPaintHook);

--- a/modules/init/src/main.cpp
+++ b/modules/init/src/main.cpp
@@ -47,6 +47,7 @@ void main() {
     g_PreLoopListener->addListener(GZ_setCursorColor);
     g_PreLoopListener->addListener(GZ_handleRelTools);
     g_PreLoopListener->addListener(GZ_drawPolygons);
+    g_PreLoopListener->addListener(GZ_updateActorMoveMgr);
 
     // Init the post-loop listener
     g_PostLoopListener = new PostLoopListener();


### PR DESCRIPTION
This is a system that moves actors for injected saves. 

A request is made by calling either `gActorMoveMgr.SetPosYaw()` or `gActorMoveMgr.SetPos()`, depending on if you want to change the Y rotation. Then the request gets tried over and over again until an actor is fully loaded to accept the request.

This is not my ideal solution to this problem, and also required a bit of a hack. I had to delay the change of position by 1 frame after the actor is available. For some reason this is necessary to move Link and potentially other actors (maybe depends on preloading idk)

In the future the system could be expanded to use `fopAcIt_Judge` for more fine grained searching