### PR TITLE
New "Actor Modification Request" System

### DIFF
--- a/external/libtww/include/f_op/f_op_actor_iter.h
+++ b/external/libtww/include/f_op/f_op_actor_iter.h
@@ -6,19 +6,6 @@
 
 typedef void* (*fopAcIt_JudgeFunc)(void*, void*);
 
-
-#define fpcSch_JudgeForPName fpcSch_JudgeForPName__FPvPv
-
-extern "C" {
-void* fpcSch_JudgeForPName(void*, void*);
-}
-
 LIBTWW_DEFINE_FUNC(fopAcIt_Judge__FPFPvPv_PvPv, void*, fopAcIt_Judge, (fopAcIt_JudgeFunc, void*))
-
-extern "C" {
-inline void* fopAcM_SearchByName(s16 name) {
-    return fopAcIt_Judge(fpcSch_JudgeForPName, &name);
-}
-}
 
 #endif

--- a/external/libtww/include/f_op/f_op_actor_iter.h
+++ b/external/libtww/include/f_op/f_op_actor_iter.h
@@ -1,0 +1,24 @@
+#ifndef F_OP_ACTOR_ITER_H_
+#define F_OP_ACTOR_ITER_H_
+
+#include "f_op_actor.h"
+#include "../defines.h"
+
+typedef void* (*fopAcIt_JudgeFunc)(void*, void*);
+
+
+#define fpcSch_JudgeForPName fpcSch_JudgeForPName__FPvPv
+
+extern "C" {
+void* fpcSch_JudgeForPName(void*, void*);
+}
+
+LIBTWW_DEFINE_FUNC(fopAcIt_Judge__FPFPvPv_PvPv, void*, fopAcIt_Judge, (fopAcIt_JudgeFunc, void*))
+
+extern "C" {
+inline void* fopAcM_SearchByName(s16 name) {
+    return fopAcIt_Judge(fpcSch_JudgeForPName, &name);
+}
+}
+
+#endif

--- a/external/libtww/include/f_op/f_op_actor_mng.h
+++ b/external/libtww/include/f_op/f_op_actor_mng.h
@@ -3,6 +3,7 @@
 
 #include "f_op_actor.h"
 #include "../f_pc/f_pc_manager.h"
+#include "../defines.h"
 
 struct fopAcM_prmBase_class {
     /* 0x00 */ u32 field_0x00;
@@ -61,5 +62,7 @@ inline void fopAcM_OffStatus(fopAc_ac_c* pActor, u32 flag) {
 inline csXyz* fopAcM_GetAngle_p(fopAc_ac_c* i_actor) {
     return &i_actor->current.angle;
 }
+
+LIBTWW_DEFINE_FUNC(fopAcM_SearchByName__FsPP10fopAc_ac_c, s32, fopAcM_SearchByName, (u32, fopAc_ac_c**))
 
 #endif

--- a/modules/boot/include/boot.h
+++ b/modules/boot/include/boot.h
@@ -26,6 +26,7 @@ void GZ_handleMenu();
 void GZ_renderMenuTitle();
 void GZ_displaySplash();
 void GZ_endlessNightOnTitle();
+void GZ_processActorModRequests();
 void GZ_handleFlags_PreLoop();
 void GZ_handleFlags_PostLoop();
 

--- a/modules/boot/src/main.cpp
+++ b/modules/boot/src/main.cpp
@@ -21,6 +21,7 @@
 #include "events/draw_listener.h"
 #include "events/pre_loop_listener.h"
 #include "events/post_loop_listener.h"
+#include "save_manager.h"
 
 #define isWidescreen (false)
 
@@ -211,4 +212,8 @@ KEEP_FUNC void GZ_endlessNightOnTitle() {
     g_env_light.mColpatCurr = 1;
     g_env_light.mThunderEff.mMode = 1;
     g_env_light.mRainCount = 250;
+}
+
+KEEP_FUNC void GZ_processActorModRequests() {
+    gSaveManager.ProcessActorModRequests();
 }

--- a/modules/boot/src/save_manager.cpp
+++ b/modules/boot/src/save_manager.cpp
@@ -182,8 +182,8 @@ KEEP_FUNC void SaveManager::ProcessActorModRequests() {
     // first `mNextStage.mEnable` is checked.
     // Then on the other side of the load, it is necessary to wait for the scene/stage/room to finish
     // processing, because these creation steps can sometimes modify actors.
-    // `l_fopScnRq_IsUsingOfOverlap` indicates if the scene request is about to fade back in, which
-    // will only happen when the room is initialized and ready to be played.
+    // When `l_fopScnRq_IsUsingOfOverlap` is false, the scene is done loading and the fade in
+    // will begin. This gurantees that the stage/room is ready and actors can be modified.
 
     if (!g_dComIfG_gameInfo.play.mNextStage.mEnable && !l_fopScnRq_IsUsingOfOverlap) {
         for (auto req = mDeque.begin(); req != mDeque.end(); ++req) {
@@ -208,8 +208,7 @@ KEEP_FUNC void SaveManager::ProcessActorModRequests() {
 
                 // Dont allow attempts to last longer than 5 seconds
                 if (req->attempts >= 150) {
-                    OSReport("ProcessActorModRequests: Couldn't find actor:%d, deleting req:%d\n", req->procName,
-                             req->id);
+                    OSReport("Couldn't find actor:%d, deleting req:%d\n", req->procName, req->id);
                     RemoveActorModRequest(req->id);
                 }
             }

--- a/modules/boot/src/save_specials.cpp
+++ b/modules/boot/src/save_specials.cpp
@@ -4,9 +4,30 @@
 #include "flags.h"
 #include "save_manager.h"
 #include "save_specials.h"
+#include "libtww/include/d/d_procname.h"
+#include "libtww/include/d/a/d_a_player_main.h"
 #include "rels/include/defines.h"
 
 // =================== UTILITIES ===================
+
+inline void SaveMngSpecial_SetActorPos(fopAc_ac_c* actor, f32 x, f32 y, f32 z) {
+    actor->current.pos.set(x, y, z);
+
+    if (actor->mBase.mProcName == PROC_PLAYER) {
+        l_debug_keep_pos.x = x;
+        l_debug_keep_pos.y = y;
+        l_debug_keep_pos.z = z;
+    }
+}
+
+inline void SaveMngSpecial_SetActorRot(fopAc_ac_c* actor, s16 xRot, s16 yRot, s16 zRot) {
+    actor->current.angle.set(xRot, yRot, zRot);
+    actor->shape_angle.set(xRot, yRot, zRot);
+}
+
+inline void SaveMngSpecial_SetActorYaw(fopAc_ac_c* actor, s16 yRot) {
+    actor->current.angle.y = actor->shape_angle.y = yRot;
+}
 
 inline void SaveMngSpecial_SetHealth(u16 health) {
     g_dComIfG_gameInfo.info.getPlayer().getPlayerStatusA().setLife(health);
@@ -148,14 +169,11 @@ KEEP_FUNC void SaveMngSpecial_PGSkip_Any() {
 KEEP_FUNC void SaveMngSpecial_BombsSwim_NoMSS() {
     SaveMngSpecial_SetLayer0();
 
-    // TODO replace with actor mod system later when it exists
-    fopAc_ac_c* ship_p = g_dComIfG_gameInfo.play.mpPlayerPtr[2];
-
-    if (ship_p != nullptr) {
-        // set KorL's pos and angle to be the same as when the Wind Waker cutscene ends
-        ship_p->current.pos.set(196459.0f, 0.0f, -199693.0f);
-        ship_p->current.angle.y = ship_p->shape_angle.y = 0x623E;
-    }
+    gSaveManager.modifyActor(PROC_SHIP, [](fopAc_ac_c* actor) {
+        OSReport("korlX:%8X\n", &actor->current.pos.x);
+        SaveMngSpecial_SetActorPos(actor, 196459.0f, 0.0f, -199693.0f);
+        SaveMngSpecial_SetActorYaw(actor, 0x623E);
+    });
 }
 
 // =================== ALL DUNGEONS FUNCTIONS ===================

--- a/modules/boot/src/save_specials.cpp
+++ b/modules/boot/src/save_specials.cpp
@@ -10,7 +10,7 @@
 
 // =================== UTILITIES ===================
 
-inline void SaveMngSpecial_SetActorPos(fopAc_ac_c* actor, f32 x, f32 y, f32 z) {
+void SaveMngSpecial_SetActorPos(fopAc_ac_c* actor, f32 x, f32 y, f32 z) {
     actor->current.pos.set(x, y, z);
 
     if (actor->mBase.mProcName == PROC_PLAYER) {

--- a/modules/boot/src/save_specials.cpp
+++ b/modules/boot/src/save_specials.cpp
@@ -170,7 +170,6 @@ KEEP_FUNC void SaveMngSpecial_BombsSwim_NoMSS() {
     SaveMngSpecial_SetLayer0();
 
     gSaveManager.modifyActor(PROC_SHIP, [](fopAc_ac_c* actor) {
-        OSReport("korlX:%8X\n", &actor->current.pos.x);
         SaveMngSpecial_SetActorPos(actor, 196459.0f, 0.0f, -199693.0f);
         SaveMngSpecial_SetActorYaw(actor, 0x623E);
     });

--- a/modules/init/src/main.cpp
+++ b/modules/init/src/main.cpp
@@ -52,6 +52,7 @@ void main() {
     g_PostLoopListener = new PostLoopListener();
     g_PostLoopListener->addListener(GZ_handleFlags_PostLoop);
     g_PostLoopListener->addListener(GZ_setCursorColor);
+    g_PostLoopListener->addListener(GZ_processActorModRequests);
 }
 void exit() {}
 


### PR DESCRIPTION
Now this works for all actors for real ™️ 

The tldr of all the changes is: Now there is a system to make actor modification requests from within a "special" function, and then it gets stored to be executed after the loading zone, and after the actor is fully loaded in and the scene is initialized and running.

There are two ways to make a request. The first way is to simply specify a proc name for an actor. This is effective if there is only *one* instance of this actor at any given time. For example, for Link or Korl. The code looks like this :
```c
    gSaveManager.modifyActor(PROC_SHIP, [](fopAc_ac_c* actor) {
        SaveMngSpecial_SetActorPos(actor, 196459.0f, 0.0f, -199693.0f);
        SaveMngSpecial_SetActorYaw(actor, 0x623E);
    });
```
Another way to make a request is to use a "judge" search function. This is required if there is more than one instance of a given actor. You must make a separate function to identify the actor based on whatever unique identifier is may have, like by its params or location.
Here is an example of using a search callback (but NOTE it is pointless to use this method in this context with locating Korl):
```c
void* SaveMngSpecial_FindKorl(void* iter, void* data) {
    fopAc_ac_c* actor = (fopAc_ac_c*)iter;
    if (actor->mBase.mProcName == PROC_SHIP && actor->mBase.mParameters == 0x1234) {
        // (this is a fake example, these params make no sense)
        return actor;
    }
    return nullptr;
}

KEEP_FUNC void SaveMngSpecial_BombsSwim_NoMSS() {
    SaveMngSpecial_SetLayer0();

    gSaveManager.modifyActor(SaveMngSpecial_FindKorl, [](fopAc_ac_c* actor) {
        SaveMngSpecial_SetActorPos(actor, 196459.0f, 0.0f, -199693.0f);
        SaveMngSpecial_SetActorYaw(actor, 0x623E);
    });
}
```