### PR TITLE
Fix endless night on second opening

### DIFF
--- a/modules/boot/src/utils/hook.cpp
+++ b/modules/boot/src/utils/hook.cpp
@@ -76,8 +76,9 @@ int dScnPly__phase_1Hook(void* i_scene) {
 
 int dScnPly__phase_4Hook(void* i_scene) {
     int ret = dScnPly__phase_4Trampoline(i_scene);
+    s16 scene = fpcM_GetName(i_scene);
 
-    if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE || fpcM_GetName(i_scene) == PROC_OPENING2_SCENE) {
+    if (scene == PROC_OPENING_SCENE || scene == PROC_OPENING2_SCENE) {
         g_PreLoopListener->addListener(GZ_endlessNightOnTitle);
     }
 
@@ -85,7 +86,9 @@ int dScnPly__phase_4Hook(void* i_scene) {
 }
 
 int dScnPly_DeleteHook(void* i_scene) {
-    if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE || fpcM_GetName(i_scene) == PROC_OPENING2_SCENE) {
+    s16 scene = fpcM_GetName(i_scene);
+
+    if (scene == PROC_OPENING_SCENE || scene == PROC_OPENING2_SCENE) {
         g_PreLoopListener->removeListener(GZ_endlessNightOnTitle);
     }
 

--- a/modules/boot/src/utils/hook.cpp
+++ b/modules/boot/src/utils/hook.cpp
@@ -77,7 +77,7 @@ int dScnPly__phase_1Hook(void* i_scene) {
 int dScnPly__phase_4Hook(void* i_scene) {
     int ret = dScnPly__phase_4Trampoline(i_scene);
 
-    if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE) {
+    if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE || fpcM_GetName(i_scene) == PROC_OPENING2_SCENE) {
         g_PreLoopListener->addListener(GZ_endlessNightOnTitle);
     }
 
@@ -85,7 +85,7 @@ int dScnPly__phase_4Hook(void* i_scene) {
 }
 
 int dScnPly_DeleteHook(void* i_scene) {
-    if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE) {
+    if (fpcM_GetName(i_scene) == PROC_OPENING_SCENE || fpcM_GetName(i_scene) == PROC_OPENING2_SCENE) {
         g_PreLoopListener->removeListener(GZ_endlessNightOnTitle);
     }
 


### PR DESCRIPTION
Turns out there are technically two copies of the title screen. At least, the title screen that leads into a video demo instead of the intro is a separate scene: `PROC_OPENING_SCENE` vs `PROC_OPENING2_SCENE`

I only noticed this accidentally after leaving dolphin on idle in the background lol