### PR TITLE
Fix collider view in frame advance

### DIFF
--- a/external/libtww/include/d/cc/d_cc_s.h
+++ b/external/libtww/include/d/cc/d_cc_s.h
@@ -5,11 +5,45 @@
 #include "d_cc_d.h"
 #include "d_cc_mass_s.h"
 
+struct dCcS__vtable_t {
+  /* 0x00 */ void* rtti;
+  /* 0x04 */ void* pad;
+  /* 0x08 */ void* CalcTgPlusDmg;
+  /* 0x0C */ void* SetPosCorrect;
+  /* 0x10 */ void* SetCoGObjInf;
+  /* 0x14 */ void* SetAtTgGObjInf;
+  /* 0x18 */ void* ChkNoHitGAtTg;
+  /* 0x1C */ void* ChkAtTgHitAfterCross;
+  /* 0x20 */ void* ChkNoHitGCo;
+  /* 0x24 */ void* dtor;
+  /* 0x28 */ void* MoveAfterCheck;
+  /* 0x2C */ void* SetCoGCorrectProc;
+  /* 0x30 */ void* CalcParticleAngle;
+};
+
+extern "C" dCcS__vtable_t __vt__4dCcS;
+
+LIBTWW_DEFINE_FUNC(__ct__4cCcSFv,
+                  void, cCcS__ctor, (cCcS*))
+
+LIBTWW_DEFINE_FUNC(__ct__12dCcMassS_MngFv,
+                  void, dCcMassS_Mng__ctor, (dCcMassS_Mng*))
+
 class dCcS : public cCcS {
 public:
+    dCcS() {
+        cCcS__ctor(this);
+        vtable = &__vt__4dCcS;
+        dCcMassS_Mng__ctor(&mMass_Mng);
+    }
+
     /* 0x284C */ dCcMassS_Mng mMass_Mng;
 };  // Size = 0x29f4
 
+
+LIBTWW_DEFINE_FUNC(__dt__4dCcSFv,
+                  void, dCcS__dtor, (dCcS*))
+                  
 static_assert(sizeof(dCcS) == 0x29f4);
 
 #endif /* D_CC_D_CC_S_H */

--- a/modules/boot/include/gz_flags.h
+++ b/modules/boot/include/gz_flags.h
@@ -3,6 +3,7 @@
 #include "font.h"
 #include "settings.h"
 #include "fifo_queue.h"
+#include "libtww/include/d/com/d_com_inf_game.h"
 
 #define MAX_GZ_FLAGS 1
 
@@ -13,7 +14,9 @@ struct GZFlag {
     void (*mpDeactiveFunc)();
 };
 
-extern bool g_framePaused;
+extern bool g_FrameAdvEnabled;
+extern bool g_FrameTriggered;
+extern dCcS* g_dCcSCopy;
 
 enum LoopPhase {
     GAME_LOOP,

--- a/modules/boot/src/gz_flags.cpp
+++ b/modules/boot/src/gz_flags.cpp
@@ -4,11 +4,9 @@
 #include "scene.h"
 #include "tools.h"
 #include "rels/include/defines.h"
-#include "geometry_draw.h"
 #include "libtww/include/m_Do/m_Do_printf.h"
 #include "libtww/include/m_Do/m_Do_controller_pad.h"
 #include "libtww/include/d/d_s_play.h"
-#include "libtww/include/d/com/d_com_inf_game.h"
 
 GZFlag g_gzFlags[MAX_GZ_FLAGS] = {
     {&g_sceneFlags[MUTE_BGM_INDEX].active, GAME_LOOP, GZ_disableBGM, GZ_enableBGM},
@@ -48,8 +46,6 @@ KEEP_FUNC void GZ_frameAdvance() {
             }
         } else if (g_FrameAdvEnabled) {
             dScnPlay_nextPauseTimer = 1;  // constantly set the timer to 1 to freeze the game
-
-            GZ_drawCc(g_dCcSCopy);
 
             if (CPad_CHECK_HOLD_UP(CONTR_1)) {
                 sAdvHoldCounter++;

--- a/modules/boot/src/gz_flags.cpp
+++ b/modules/boot/src/gz_flags.cpp
@@ -4,9 +4,11 @@
 #include "scene.h"
 #include "tools.h"
 #include "rels/include/defines.h"
+#include "geometry_draw.h"
 #include "libtww/include/m_Do/m_Do_printf.h"
 #include "libtww/include/m_Do/m_Do_controller_pad.h"
 #include "libtww/include/d/d_s_play.h"
+#include "libtww/include/d/com/d_com_inf_game.h"
 
 GZFlag g_gzFlags[MAX_GZ_FLAGS] = {
     {&g_sceneFlags[MUTE_BGM_INDEX].active, GAME_LOOP, GZ_disableBGM, GZ_enableBGM},
@@ -24,8 +26,11 @@ void GZ_execute(int phase) {
     }
 }
 
+bool g_FrameAdvEnabled = false;
+bool g_FrameTriggered = false;
+dCcS* g_dCcSCopy;
+
 KEEP_FUNC void GZ_frameAdvance() {
-    static bool sFrameAdvEnabled = false;
     static int sAdvHoldCounter = 0;
     static u16 sBufferedInputs;
 
@@ -33,9 +38,18 @@ KEEP_FUNC void GZ_frameAdvance() {
         bool openingMenu = CPad_CHECK_HOLD_R(CONTR_1) && CPad_CHECK_HOLD_L(CONTR_1);
 
         if (!openingMenu && CPad_CHECK_TRIG_DOWN(CONTR_1)) {
-            sFrameAdvEnabled = !sFrameAdvEnabled;
-        } else if (sFrameAdvEnabled) {
+            g_FrameAdvEnabled = !g_FrameAdvEnabled;
+
+            if (g_FrameAdvEnabled) {
+                g_dCcSCopy = new dCcS();
+            } else {
+                dCcS__dtor(g_dCcSCopy);
+                delete g_dCcSCopy;
+            }
+        } else if (g_FrameAdvEnabled) {
             dScnPlay_nextPauseTimer = 1;  // constantly set the timer to 1 to freeze the game
+
+            GZ_drawCc(g_dCcSCopy);
 
             if (CPad_CHECK_HOLD_UP(CONTR_1)) {
                 sAdvHoldCounter++;
@@ -48,7 +62,10 @@ KEEP_FUNC void GZ_frameAdvance() {
             memcpy(&pressedButtons, &g_mDoCPd_cpadInfo[CONTR_1].mButtonTrig, sizeof(pressedButtons));
             sBufferedInputs |= pressedButtons;
 
-            if (CPad_CHECK_TRIG_UP(CONTR_1) || sAdvHoldCounter >= 30) {
+            // Frame triggered state is stored to check in dCcS hooks later
+            g_FrameTriggered = CPad_CHECK_TRIG_UP(CONTR_1) || sAdvHoldCounter >= 30;
+
+            if (g_FrameTriggered) {
                 // copy buffered inputs to controller
                 memcpy(&g_mDoCPd_cpadInfo[CONTR_1].mButtonTrig, &sBufferedInputs, sizeof(sBufferedInputs));
                 memcpy(&g_mDoCPd_cpadInfo[CONTR_1].mButtonHold, &sBufferedInputs, sizeof(sBufferedInputs));
@@ -58,7 +75,7 @@ KEEP_FUNC void GZ_frameAdvance() {
                 g_mDoCPd_cpadInfo[CONTR_1].mButtonTrig.up = 0;
                 g_mDoCPd_cpadInfo[CONTR_1].mButtonHold.up = 0;
 
-                dScnPlay_nextPauseTimer = 0;  // set pause timer to 0 to advance 1 frame
+                dScnPlay_nextPauseTimer = 0;  // set pause timer to 0 to advance one frame
             }
         }
     }


### PR DESCRIPTION
Before, the collider queue was being cleared every time a frame was drawn which would cause the collider view to show for a frame and then dissapear.

Per advice from @TakaRikka , this fix copies the dCcS class every time a frame is advanced, so that this data can live separately from the game and still be drawn 