### PR TITLE
Add Move Link

### DIFF
--- a/modules/boot/include/commands.h
+++ b/modules/boot/include/commands.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "libtww/include/dolphin/gctypes.h"
 
-#define COMMANDS_AMNT 17
+#define COMMANDS_AMNT 18
 
 extern bool g_commandStates[COMMANDS_AMNT];
 extern bool g_timer_reset;
@@ -29,6 +29,7 @@ enum Commands {
     CMD_RESET_TIMER,
     CMD_VOID,
     CMD_HOVER_BOOTS,
+    CMD_MOVE_LINK
 };
 
 struct Command {

--- a/modules/boot/include/modules.h
+++ b/modules/boot/include/modules.h
@@ -14,5 +14,6 @@ void GZ_handleModules();
 
 bool inputViewer_active();
 bool actorView_active();
+bool moveLink_active();
 bool rollClipTool_active();
 bool pauseBufferInputTool_active();

--- a/modules/boot/include/tools.h
+++ b/modules/boot/include/tools.h
@@ -18,6 +18,7 @@ enum ToolsIndex {
     VOID_INDEX,
     ROLL_CLIP_INDEX,
     PAUSE_BUFFER_INPUT_INDEX,
+    MOVE_LINK_INDEX,
 
     // Entry used as a counter
     TOOLS_COUNT

--- a/modules/boot/src/commands.cpp
+++ b/modules/boot/src/commands.cpp
@@ -171,6 +171,12 @@ void GZCmd_void() {
     }
 }
 
+void GZCmd_moveLink() {
+    if (GZCmd_checkTrig(CButton::L | CButton::R | CButton::Y)) {
+        g_moveLinkEnabled = !g_moveLinkEnabled;
+    }
+}
+
 static Command sCommands[COMMANDS_AMNT] = {
     {g_commandStates[CMD_STORE_POSITION], (CButton::DPAD_UP | CButton::R), GZCmd_storePosition},
     {g_commandStates[CMD_LOAD_POSITION], (CButton::DPAD_DOWN | CButton::R), GZCmd_loadPosition},
@@ -189,8 +195,7 @@ static Command sCommands[COMMANDS_AMNT] = {
     {g_commandStates[CMD_RESET_TIMER], (CButton::DPAD_LEFT | CButton::R | CButton::L), GZCmd_resetTimer},
     {g_commandStates[CMD_VOID], (CButton::L | CButton::R | CButton::B | CButton::START), GZCmd_void},
     {g_commandStates[CMD_HOVER_BOOTS], (CButton::L | CButton::R | CButton::DPAD_UP), GZCmd_hoverBoots},
-
-};
+    {g_commandStates[CMD_MOVE_LINK], (CButton::L | CButton::R | CButton::Y), GZCmd_moveLink}};
 
 void GZCmd_processInputs() {
     sCurInputs = GZ_getButtonStatus();

--- a/modules/boot/src/global_data.cpp
+++ b/modules/boot/src/global_data.cpp
@@ -6,7 +6,7 @@ KEEP_VAR u8 g_geometryOpacity = 0x80;
 KEEP_VAR u8 g_collisionRaise = 1;
 
 KEEP_VAR fopAc_ac_c* g_currentActor;
-KEEP_VAR bool g_moveLinkEnabled;
+KEEP_VAR bool g_moveLinkEnabled = false;
 KEEP_VAR bool g_actorViewEnabled;
 KEEP_VAR procBinData g_procData;
 KEEP_VAR procBinData g_procInit;

--- a/modules/boot/src/main.cpp
+++ b/modules/boot/src/main.cpp
@@ -3,6 +3,7 @@
 #include "fifo_queue.h"
 #include "font.h"
 #include "gz_flags.h"
+#include "global_data.h"
 #include "libtww/include/m_Do/m_Do_printf.h"
 #include "menu.h"
 #include "settings.h"
@@ -111,6 +112,7 @@ KEEP_FUNC void GZ_handleMenu() {
 
     if (l_fopScnRq_IsUsingOfOverlap) {
         g_menuMgr->hide();
+        g_moveLinkEnabled = false;
         last_frame_was_loading = true;
     }
 

--- a/modules/boot/src/modules.cpp
+++ b/modules/boot/src/modules.cpp
@@ -31,6 +31,10 @@ KEEP_FUNC bool actorView_active() {
     return g_actorViewEnabled;
 }
 
+KEEP_FUNC bool moveLink_active() {
+    return g_tools[MOVE_LINK_INDEX].active;
+}
+
 KEEP_FUNC bool rollClipTool_active() {
     return g_tools[ROLL_CLIP_INDEX].active;
 }

--- a/modules/boot/src/tools.cpp
+++ b/modules/boot/src/tools.cpp
@@ -1,13 +1,21 @@
 #include "tools.h"
 #include "rels/include/defines.h"
 
-KEEP_VAR Tool g_tools[TOOLS_COUNT] = {
-    {DEBUG_INDEX, false},       {TIME_DISP_INDEX, false},
-    {STAGE_INFO_INDEX, false},  {TELEPORT_INDEX, false},
-    {AREA_RELOAD_INDEX, false}, {MAP_SELECT_INDEX, false},
-    {ZH_INDEX, false},          {INPUT_VIEWER_INDEX, false},
-    {FRAME_COUNT_INDEX, false}, {FRAME_ADVANCE_INDEX, false},
-    {ESS_CHECKER_INDEX, false}, {DEADZONE_CHECKER_INDEX, false},
-    {INTRO_SKIP_INDEX, false},  {DISABLE_SVCHECK_INDEX, false},
-    {VOID_INDEX, false},
-};
+KEEP_VAR Tool g_tools[TOOLS_COUNT] = {{DEBUG_INDEX, false},
+                                      {TIME_DISP_INDEX, false},
+                                      {STAGE_INFO_INDEX, false},
+                                      {TELEPORT_INDEX, false},
+                                      {AREA_RELOAD_INDEX, false},
+                                      {MAP_SELECT_INDEX, false},
+                                      {ZH_INDEX, false},
+                                      {INPUT_VIEWER_INDEX, false},
+                                      {FRAME_COUNT_INDEX, false},
+                                      {FRAME_ADVANCE_INDEX, false},
+                                      {ESS_CHECKER_INDEX, false},
+                                      {DEADZONE_CHECKER_INDEX, false},
+                                      {INTRO_SKIP_INDEX, false},
+                                      {DISABLE_SVCHECK_INDEX, false},
+                                      {VOID_INDEX, false},
+                                      {ROLL_CLIP_INDEX, false},
+                                      {PAUSE_BUFFER_INPUT_INDEX, false},
+                                      {MOVE_LINK_INDEX, false}};

--- a/modules/features/moveactor/include/moveactor.h
+++ b/modules/features/moveactor/include/moveactor.h
@@ -3,6 +3,6 @@
 #include "libtww/include/d/com/d_com_inf_game.h"
 
 namespace MoveActor {
-void move(fopAc_ac_c* actor);
+void move(daPy_lk_c* actor);
 void execute();
 }  // namespace MoveActor

--- a/modules/features/moveactor/src/main.cpp
+++ b/modules/features/moveactor/src/main.cpp
@@ -1,14 +1,14 @@
 #include <main.h>
 #include "features/moveactor/include/moveactor.h"
 #include "rels/include/cxx.h"
-#include "events/pre_loop_listener.h"
+#include "events/post_loop_listener.h"
 
 namespace twwgz::modules {
 void main() {
-    g_PreLoopListener->addListener(MoveActor::execute);
+    g_PostLoopListener->addListener(MoveActor::execute);
 }
 void exit() {
-    g_PreLoopListener->removeListener(MoveActor::execute);
+    g_PostLoopListener->removeListener(MoveActor::execute);
 }
 
 }  // namespace twwgz::modules

--- a/modules/features/moveactor/src/moveactor.cpp
+++ b/modules/features/moveactor/src/moveactor.cpp
@@ -1,23 +1,17 @@
 #include "features/moveactor/include/moveactor.h"
-#include <cstdio>
-#include "font.h"
 #include "global_data.h"
 #include "libtww/include/MSL_C/math.h"
-#include "settings.h"
 #include "libtww/include/JSystem/JUtility/JUTGamePad.h"
-// #include "libtp_c/include/f_op/f_op_draw_tag.h"
-// #include "libtww/include/m_Do/m_Re_controller_pad.h"
 #include "rels/include/defines.h"
-#include "libtww/include/d/d_meter.h"
-#include "libtww/include/d/d_procname.h"
 #include "libtww/include/d/a/d_a_player_main.h"
+#include "menus/menu_tools/include/tools_menu.h"
 
-#define ROTATION_SPEED (30)
-#define ROTATION_FAST_SPEED (80)
-#define ROTATION_VERY_FAST_SPEED (800)
+#define ROTATION_SPEED (15)
+#define ROTATION_FAST_SPEED (25)
+#define ROTATION_VERY_FAST_SPEED (25)
 #define CAM_SPEED (1.0)
-#define CAM_FAST_SPEED (2.5)
-#define CAM_VERY_FAST_SPEED (10.0)
+#define CAM_FAST_SPEED (4)
+#define CAM_VERY_FAST_SPEED (60.0)
 #define DIST_FROM_ACTOR (600)
 
 #define CONTROL_Y (mPadStatus.stick_y)
@@ -31,17 +25,41 @@
 #define WHITE_RGBA 0xFFFFFFFF
 #define LINE_X_OFFSET 20.0f
 
+// Get 2 vectors at a specific memory address.
+// These CAM_TARGET and CAM_POS vectors are special
+// because changing their values actually affect the camera in the game.
+// There sould be a cleaner way to get these vectors
+// but it is not in the decomp files available in gz
+#ifdef NTSCJ
+#define UNK_POINTER1 *(uintptr_t*)0x803AD380
+#endif
+#ifdef NTSCU
+#define UNK_POINTER1 *(uintptr_t*)0x803B9E80
+#endif
+#ifdef PAL
+#define UNK_POINTER1 *(uintptr_t*)0x803C0B80
+#endif
+
+#define UNK_POINTER2 (uintptr_t*)(UNK_POINTER1 + 0x34)
+#define CAM_TARGET (Vec*)(*UNK_POINTER2 + 0x288);
+#define CAM_POS (Vec*)(*UNK_POINTER2 + 0x294);
+
 namespace MoveActor {
 
 double pitch = 0.0;
 double yaw = 0.0;
 float angle = 0.0f;
-bool event_halt = false;
+bool enabled = false;
 
-void move(fopAc_ac_c* actor) {
+void move(daPy_lk_c* actor) {
+    // Avoid crashing by testing this pointer
+    if ((uintptr_t*)(UNK_POINTER1) == NULL) {
+        return;
+    }
+
     // Fetch the camera position and target
-    Vec& cam_target = g_dComIfG_gameInfo.play.mCameraInfo->mCameraTarget;
-    Vec& cam_pos = g_dComIfG_gameInfo.play.mCameraInfo->mCameraPos;
+    Vec* cam_target = CAM_TARGET;
+    Vec* cam_pos = CAM_POS;
 
     // Fetch the actor position and angles
     cXyz& actor_pos = actor->current.pos;
@@ -50,25 +68,26 @@ void move(fopAc_ac_c* actor) {
 
     // Set Link momentum to 0
     cXyz tmp(0.0f, 0.0f, 0.0f);
-    dComIfGp_getPlayer(0)->speed = tmp;
+    actor->speed = tmp;
+    actor->gravity = 0;
 
     if (!LOCK_CAMERA) {
         angle = (float)actor_horizontal_angle / 65536.f * (2 * M_PI);
     }
 
     // Fix Camera behind link
-    cam_target.x = actor_pos.x;
-    cam_target.y = actor_pos.y + 200.f;
-    cam_target.z = actor_pos.z;
-    cam_pos.z = actor_pos.z - DIST_FROM_ACTOR * cos(angle);
-    cam_pos.x = actor_pos.x - DIST_FROM_ACTOR * sin(angle);
-    cam_pos.y = actor_pos.y + 200.f;
+    cam_target->x = actor_pos.x;
+    cam_target->y = actor_pos.y + 200.f;
+    cam_target->z = actor_pos.z;
+    cam_pos->z = actor_pos.z - DIST_FROM_ACTOR * cos(angle);
+    cam_pos->x = actor_pos.x - DIST_FROM_ACTOR * sin(angle);
+    cam_pos->y = actor_pos.y + 200.f;
 
     // Calculate the pitch and yaw
-    yaw = atan2(cam_target.z - cam_pos.z, cam_target.x - cam_pos.x);
-    double horizontal = sqrtf((cam_target.x - cam_pos.x) * (cam_target.x - cam_pos.x) +
-                              (cam_target.z - cam_pos.z) * (cam_target.z - cam_pos.z));
-    pitch = atan2(cam_target.y - cam_pos.y, horizontal);
+    yaw = atan2(cam_target->z - cam_pos->z, cam_target->x - cam_pos->x);
+    double horizontal = sqrtf((cam_target->x - cam_pos->x) * (cam_target->x - cam_pos->x) +
+                              (cam_target->z - cam_pos->z) * (cam_target->z - cam_pos->z));
+    pitch = atan2(cam_target->y - cam_pos->y, horizontal);
 
     // Calculate the translation
     double dy = LOCK_CAMERA ? 0.0f : VERTICAL_DISPLACEMENT;
@@ -92,48 +111,65 @@ void move(fopAc_ac_c* actor) {
     } else {
         actor_horizontal_angle -= HORIZONTAL_DISPLACEMENT * cam_speed;
     }
+
+    // Apply in game all the changes made
+    l_debug_keep_pos = actor_pos;
+    l_debug_current_angle.x = actor_verticle_angle;
+    l_debug_current_angle.y = actor_horizontal_angle;
+    l_debug_shape_angle.x = actor_verticle_angle;
+    l_debug_shape_angle.y = actor_horizontal_angle;
 }
 
 KEEP_FUNC void execute() {
     daPy_lk_c* player_p = (daPy_lk_c*)dComIfGp_getPlayer(0);
-
-    if (g_actorViewEnabled || g_moveLinkEnabled) {
-        // Hide HUD
-        g_meterHIO.field_0x18 = 0.0f;
-
+    if (!player_p) {
+        return;
+    }
+    if (g_moveLinkEnabled) {
         // Lock the camera to allow for its movement
         dComIfGp_getPEvtManager()->mCameraPlay = 1;
 
-        // Special case for Link (this needs to be refactored to be more generic)
-        if (player_p && (g_moveLinkEnabled || g_currentActor->mBase.mProcName == PROC_PLAYER)) {
-            player_p->mAcch.SetGrndNone();
-            player_p->mAcch.SetRoofNone();
-            player_p->mAcch.OnLineCheckNone();
+        // Disable all of Link's collisions
+        player_p->mAcch.SetGrndNone();
+        player_p->mAcch.SetWallNone();
+        player_p->mAcch.SetRoofNone();
+        player_p->mAcch.OnLineCheckNone();
 
-            g_dComIfG_gameInfo.play.mEvtCtrl.mbEndProc = true;
-            event_halt = true;
+        // Disable voiding by setting the ground height to not -inf and telling the game Link is not midair
+        player_p->mAcch.m_ground_h = -9999999999.0f;
+        player_p->offModeFlg(0x00000002);
 
-            move(dComIfGp_getPlayer(0));
-        } else {
-            g_dComIfG_gameInfo.play.mEvtCtrl.mbEndProc = false;
-            event_halt = false;
+        // Disable automatic voiding/crashing in water by setting the wave level to exactly the ground height and
+        // telling the game Link is not swimming
+        player_p->m35D0 = -9999999999.0f;
+        player_p->offModeFlg(0x00040000);
 
-            move(g_currentActor);
-        }
+        // Disable drowning
+        g_dComIfG_gameInfo.play.field_0x4928 = false;
+
+        enabled = true;
+
+        move(player_p);
+
+        // Disable the X, Y and Z buttons to avoid using items
+        mPadButton.mButton = mPadButton.mButton | CButton::Z | CButton::X | CButton::Y;
+
     } else {
-        if (event_halt) {
-            if (player_p) {
-                player_p->mAcch.ClrGrndNone();
-                player_p->mAcch.ClrWallNone();
-                player_p->mAcch.ClrRoofNone();
-                player_p->mAcch.OffLineCheckNone();
-            }
+        if (enabled) {
+            // Enable all of Link's collisions back
+            player_p->mAcch.ClrGrndNone();
+            player_p->mAcch.ClrWallNone();
+            player_p->mAcch.ClrRoofNone();
+            player_p->mAcch.OffLineCheckNone();
 
-            g_dComIfG_gameInfo.play.mEvtCtrl.mbEndProc = false;
-            event_halt = false;
+            // Enable voiding by telling the game Link is midair
+            player_p->onModeFlg(0x00000002);
 
+            // Disable fixed camera and bring back gravity
             dComIfGp_getPEvtManager()->mCameraPlay = 0;
-            g_meterHIO.field_0x18 = 0.0f;
+            player_p->gravity = -2.5;
+
+            enabled = false;
         }
     }
 }

--- a/modules/features/moveactor/src/moveactor.cpp
+++ b/modules/features/moveactor/src/moveactor.cpp
@@ -130,7 +130,11 @@ KEEP_FUNC void execute() {
         dComIfGp_getPEvtManager()->mCameraPlay = 1;
 
         // Disable all of Link's collisions
-        player_p->mAcch.SetGrndNone();
+        if ((mPadButton.mButton & CButton::A)) {
+            player_p->mAcch.ClrGrndNone();
+        } else {
+            player_p->mAcch.SetGrndNone();
+        }
         player_p->mAcch.SetWallNone();
         player_p->mAcch.SetRoofNone();
         player_p->mAcch.OnLineCheckNone();

--- a/modules/init/src/main.cpp
+++ b/modules/init/src/main.cpp
@@ -66,6 +66,7 @@ void main() {
     // Init the module list
     g_modules.push_back(new Module{inputViewer_active, "/twwgz/rels/features/input_viewer.rel"});
     g_modules.push_back(new Module{actorView_active, "/twwgz/rels/features/actor_view.rel"});
+    g_modules.push_back(new Module{moveLink_active, "/twwgz/rels/features/moveactor.rel"});
     g_modules.push_back(new Module{rollClipTool_active, "/twwgz/rels/features/rollclip_tool.rel"});
     g_modules.push_back(new Module{pauseBufferInputTool_active, "/twwgz/rels/features/pause_buffer_input_tool.rel"});
 

--- a/modules/menus/menu_tools/src/tools_menu.cpp
+++ b/modules/menus/menu_tools/src/tools_menu.cpp
@@ -62,7 +62,9 @@ KEEP_FUNC ToolsMenu::ToolsMenu(Cursor& cursor)
           {"roll clip trainer", ROLL_CLIP_INDEX, "Train roll clip timing with an OSD", true,
            &g_tools[ROLL_CLIP_INDEX].active},
           {"pause buffer input trainer", PAUSE_BUFFER_INPUT_INDEX, "Train pause buffered input timing with an OSD",
-           true, &g_tools[PAUSE_BUFFER_INPUT_INDEX].active}} {}
+           true, &g_tools[PAUSE_BUFFER_INPUT_INDEX].active},
+          {"move link", MOVE_LINK_INDEX, "Move Link around freely by pressing L + R + Y", true,
+           &g_tools[MOVE_LINK_INDEX].active}} {}
 
 ToolsMenu::~ToolsMenu() {}
 
@@ -102,6 +104,9 @@ void ToolsMenu::draw() {
                 DCFlushRange(reinterpret_cast<u32*>(INTRO_SKIP_INST1_ADDR), sizeof(u32));
                 ICInvalidateRange(reinterpret_cast<u32*>(INTRO_SKIP_INST1_ADDR), sizeof(u32));
                 break;
+            case MOVE_LINK_INDEX:
+                GZCmd_enable(Commands::CMD_MOVE_LINK);
+                break;
             }
         } else {
             switch (cursor.y) {
@@ -128,6 +133,10 @@ void ToolsMenu::draw() {
                 *reinterpret_cast<u32*>(INTRO_SKIP_INST1_ADDR) = INTRO_SKIP_ORIG_INST1;  // bne ret
                 DCFlushRange(reinterpret_cast<u32*>(INTRO_SKIP_INST1_ADDR), sizeof(u32));
                 ICInvalidateRange(reinterpret_cast<u32*>(INTRO_SKIP_INST1_ADDR), sizeof(u32));
+                break;
+            case MOVE_LINK_INDEX:
+                GZCmd_disable(Commands::CMD_MOVE_LINK);
+                g_moveLinkEnabled = false;
                 break;
             }
         }


### PR DESCRIPTION
This Pull Request ports the "move link" tool from tpgz. 

Features: 

- Enable the move link tool in the tools menu then press L, R and Y to enable move link
- Move Link freely without gravity and any collision check using the main stick for the X and Z axis and the C stick up and down for the Y axis
- Turn the camera using left and right input on the C stick
- Hold L and move the C stick to rotate Link without moving the camera 
- Hold Z to move 4 times faster 
- Hold both Z and R to move 60 times faster (useful to cross the ocean)
- Voiding is disabled while move link is active
- Using X, Y or Z items is disabled to avoid wasting consumables (magic, bombs) when using the tool
- Press A to temporarily enable back Link's ground collision to load the current sea quadrant

Known issue (minor) : disabling move Link during a cutscene causes the camera to become free again, breaking most small cutscenes. Enabling move Link back will sometimes resume the cutscene.

Technical note : To be able to freely move the camera, I had to get some vectors directly from a dirty access to an address in the memory since I couldn't find any other way to make this possible. I searched a lot into decomp and couldn't find a way to get a camera target and a position vector that could be modified and have an effect ingame.